### PR TITLE
Fix bugs and polish string expression

### DIFF
--- a/pepflow/expression_manager.py
+++ b/pepflow/expression_manager.py
@@ -367,7 +367,7 @@ class ExpressionManager:
         repr_str = ""
         for i, v in enumerate(evaluated_vector.coords):
             ith_tag = self.get_tag_of_basis_vector_index(i)
-            repr_str += utils.tag_and_coef_to_str(ith_tag, v)
+            repr_str += utils.coef_times_term_to_str(ith_tag, v)
 
         # Post processing
         if repr_str == "":
@@ -454,7 +454,7 @@ class ExpressionManager:
         for i, v in enumerate(evaluated_scalar.func_coords):
             # Note the tag is from scalar basis.
             ith_tag = self.get_tag_of_basis_scalar_index(i)
-            repr_str += utils.tag_and_coef_to_str(ith_tag, v)
+            repr_str += utils.coef_times_term_to_str(ith_tag, v)
 
         if greedy_square:
             diag_elem = np.diag(evaluated_scalar.inner_prod_coords).copy()
@@ -468,17 +468,17 @@ class ExpressionManager:
                     if diag_elem[i] * v > 0:  # same sign with diagonal elem
                         diag_elem[i] -= v
                         diag_elem[j] -= v
-                        repr_str += utils.tag_and_coef_to_str(
+                        repr_str += utils.coef_times_term_to_str(
                             f"|{ith_tag}+{jth_tag}|^2", v
                         )
                     else:  # different sign
                         diag_elem[i] += v
                         diag_elem[j] += v
-                        repr_str += utils.tag_and_coef_to_str(
+                        repr_str += utils.coef_times_term_to_str(
                             f"|{ith_tag}-{jth_tag}|^2", -v
                         )
                 # Handle the diagonal elements
-                repr_str += utils.tag_and_coef_to_str(f"|{ith_tag}|^2", diag_elem[i])
+                repr_str += utils.coef_times_term_to_str(f"|{ith_tag}|^2", diag_elem[i])
         else:
             for i in range(evaluated_scalar.inner_prod_coords.shape[0]):
                 ith_tag = self.get_tag_of_basis_vector_index(i)
@@ -486,9 +486,9 @@ class ExpressionManager:
                     jth_tag = self.get_tag_of_basis_vector_index(j)
                     v = evaluated_scalar.inner_prod_coords[i, j]
                     if i == j:
-                        repr_str += utils.tag_and_coef_to_str(f"|{ith_tag}|^2", v)
+                        repr_str += utils.coef_times_term_to_str(f"|{ith_tag}|^2", v)
                     else:
-                        repr_str += utils.tag_and_coef_to_str(
+                        repr_str += utils.coef_times_term_to_str(
                             f"⟨{ith_tag}, {jth_tag}⟩", 2 * v
                         )
 

--- a/pepflow/expression_manager.py
+++ b/pepflow/expression_manager.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import sympy as sp
 
+from pepflow import math_expression as me
 from pepflow import parameter as pm
 from pepflow import pep_context as pc
 from pepflow import scalar as sc
@@ -489,7 +490,7 @@ class ExpressionManager:
                         repr_str += utils.coef_times_term_to_str(f"|{ith_tag}|^2", v)
                     else:
                         repr_str += utils.coef_times_term_to_str(
-                            f"⟨{ith_tag}, {jth_tag}⟩", 2 * v
+                            me.INNER_PROD_STR.format(A=ith_tag, B=jth_tag), 2 * v
                         )
 
         # Post processing

--- a/pepflow/expression_manager_test.py
+++ b/pepflow/expression_manager_test.py
@@ -26,6 +26,7 @@ import sympy as sp
 
 from pepflow import expression_manager as exm
 from pepflow import function as fc
+from pepflow import math_expression as me
 from pepflow import pep as pep
 from pepflow import pep_context as pc
 from pepflow import scalar as sc
@@ -336,7 +337,9 @@ def test_repr_scalar_by_basis(pep_context: pc.PEPContext) -> None:
 
     s = f(x) + x * f.grad(x)
     em = exm.ExpressionManager(pep_context)
-    assert em.repr_scalar_by_basis(s, greedy_square=False) == "f(x) + ⟨x, grad_f(x)⟩"
+    assert em.repr_scalar_by_basis(s, greedy_square=False) == (
+        f"f(x) + {me.INNER_PROD_STR.format(A='x', B='grad_f(x)')}"
+    )
     assert (
         em.repr_scalar_by_basis(s, greedy_square=True)
         == "f(x) - 0.5*|x-grad_f(x)|^2 + 0.5*|x|^2 + 0.5*|grad_f(x)|^2"
@@ -349,7 +352,9 @@ def test_repr_scalar_by_basis2(pep_context: pc.PEPContext) -> None:
 
     s = f(x) - x * f.grad(x)
     em = exm.ExpressionManager(pep_context)
-    assert em.repr_scalar_by_basis(s, greedy_square=False) == "f(x) - ⟨x, grad_f(x)⟩"
+    assert em.repr_scalar_by_basis(s, greedy_square=False) == (
+        f"f(x) - {me.INNER_PROD_STR.format(A='x', B='grad_f(x)')}"
+    )
     assert (
         em.repr_scalar_by_basis(s, greedy_square=True)
         == "f(x) + 0.5*|x-grad_f(x)|^2 - 0.5*|x|^2 - 0.5*|grad_f(x)|^2"
@@ -364,7 +369,13 @@ def test_repr_scalar_by_basis_interpolation(pep_context: pc.PEPContext) -> None:
     fj = f(xj)  # noqa: F841
     interp_scalar = f.interp_ineq("x_i", "x_j", sympy_mode=False)
     em = exm.ExpressionManager(pep_context)
-    expected_repr = "-f(x_i) + f(x_j) + ⟨x_i, grad_f(x_j)⟩ - ⟨x_j, grad_f(x_j)⟩ + 0.5*|grad_f(x_i)|^2 - ⟨grad_f(x_i), grad_f(x_j)⟩ + 0.5*|grad_f(x_j)|^2"
+    xigj = me.INNER_PROD_STR.format(A="x_i", B="grad_f(x_j)")
+    xjgj = me.INNER_PROD_STR.format(A="x_j", B="grad_f(x_j)")
+    gigj = me.INNER_PROD_STR.format(A="grad_f(x_i)", B="grad_f(x_j)")
+    expected_repr = (
+        f"-f(x_i) + f(x_j) + {xigj} - {xjgj} + 0.5*|grad_f(x_i)|^2"
+        f" - {gigj} + 0.5*|grad_f(x_j)|^2"
+    )
     assert em.repr_scalar_by_basis(interp_scalar, greedy_square=False) == expected_repr
     expected_square_repr = "-f(x_i) + f(x_j) - 0.5*|x_i-grad_f(x_j)|^2 + 0.5*|x_i|^2 + 0.5*|x_j-grad_f(x_j)|^2 - 0.5*|x_j|^2 + 0.5*|grad_f(x_i)-grad_f(x_j)|^2"
     assert (
@@ -383,7 +394,13 @@ def test_repr_scalar_by_basis_interpolation_sympy_mode(
     fj = f(xj)  # noqa: F841
     interp_scalar = f.interp_ineq("x_i", "x_j", sympy_mode=True)
     em = exm.ExpressionManager(pep_context)
-    expected_repr = "-f(x_i) + f(x_j) + ⟨x_i, grad_f(x_j)⟩ - ⟨x_j, grad_f(x_j)⟩ + 1/2*|grad_f(x_i)|^2 - ⟨grad_f(x_i), grad_f(x_j)⟩ + 1/2*|grad_f(x_j)|^2"
+    xigj = me.INNER_PROD_STR.format(A="x_i", B="grad_f(x_j)")
+    xjgj = me.INNER_PROD_STR.format(A="x_j", B="grad_f(x_j)")
+    gigj = me.INNER_PROD_STR.format(A="grad_f(x_i)", B="grad_f(x_j)")
+    expected_repr = (
+        f"-f(x_i) + f(x_j) + {xigj} - {xjgj} + 1/2*|grad_f(x_i)|^2"
+        f" - {gigj} + 1/2*|grad_f(x_j)|^2"
+    )
     assert (
         em.repr_scalar_by_basis(interp_scalar, greedy_square=False, sympy_mode=True)
         == expected_repr

--- a/pepflow/math_expression.py
+++ b/pepflow/math_expression.py
@@ -19,6 +19,8 @@
 
 import attrs
 
+INNER_PROD_STR = "⟨{A},{B}⟩"
+
 
 @attrs.mutable
 class MathExpr:

--- a/pepflow/parameter_test.py
+++ b/pepflow/parameter_test.py
@@ -192,7 +192,7 @@ def test_parameter_power(pep_context: pc.PEPContext):
     assert not pp6.get_value({"pm1": 2}) == 2
 
     pp7 = sp.sqrt(2) ** pm1
-    assert str(pp7) == "(sqrt(2))**{pm1}"
+    assert str(pp7) == "(\\sqrt{2})**{pm1}"
     assert pp7.get_value({"pm1": 2}) == 2
 
 

--- a/pepflow/scalar.py
+++ b/pepflow/scalar.py
@@ -585,7 +585,7 @@ class Scalar:
         if not utils.is_numerical_or_parameter(other):
             return NotImplemented
         expr_self = utils.parenthesize_tag(self)
-        expr_other = utils.numerical_str(other)
+        expr_other = utils.parenthesize_repr(other)
         return Scalar(
             is_basis=False,
             eval_expression=ScalarRepresentation(utils.Op.MUL, self, other),
@@ -597,7 +597,7 @@ class Scalar:
         if not utils.is_numerical_or_parameter(other):
             return NotImplemented
         expr_self = utils.parenthesize_tag(self)
-        expr_other = utils.numerical_str(other)
+        expr_other = utils.parenthesize_repr(other)
         return Scalar(
             is_basis=False,
             eval_expression=ScalarRepresentation(utils.Op.MUL, other, self),
@@ -618,7 +618,7 @@ class Scalar:
         if not utils.is_numerical_or_parameter(other):
             return NotImplemented
         expr_self = utils.parenthesize_tag(self)
-        expr_other = f"1/{utils.numerical_str(other)}"
+        expr_other = f"1/{utils.parenthesize_repr(other)}"
         return Scalar(
             is_basis=False,
             eval_expression=ScalarRepresentation(utils.Op.DIV, self, other),

--- a/pepflow/scalar.py
+++ b/pepflow/scalar.py
@@ -89,7 +89,9 @@ class ScalarByBasisRepresentation:
                 coeff_str = repr(val)
             vec0_repr, vec1_repr = repr(key[0]), repr(key[1])
             if vec0_repr != vec1_repr:
-                terms.append(f"{coeff_str}*⟨{vec0_repr},{vec1_repr}⟩")
+                terms.append(
+                    f"{coeff_str}*" + me.INNER_PROD_STR.format(A=vec0_repr, B=vec1_repr)
+                )
             else:
                 terms.append(f"{coeff_str}*|{vec0_repr}|^2")
         return " + ".join(terms) if terms else "0"

--- a/pepflow/utils.py
+++ b/pepflow/utils.py
@@ -108,10 +108,7 @@ class Comparator(enum.Enum):
 
 
 def is_numerical(val: Any) -> bool:
-    val_is_sp_real = False
-    if isinstance(val, sp.Basic):
-        val_is_sp_real = val.is_real
-    return isinstance(val, numbers.Number) or val_is_sp_real
+    return isinstance(val, numbers.Number) or is_sympy_real(val)
 
 
 def is_parameter(val: Any) -> bool:
@@ -126,6 +123,13 @@ def is_numerical_or_parameter(val: Any) -> bool:
 
 def is_sympy_expr(val: Any) -> bool:
     return isinstance(val, sp.Basic)
+
+
+def is_sympy_real(val: Any) -> bool:
+    val_is_sp_real = False
+    if is_sympy_expr(val):
+        val_is_sp_real = val.is_real
+    return val_is_sp_real
 
 
 def simplify_if_param_or_sympy_expr(
@@ -186,43 +190,44 @@ def numerical_str(val: Any) -> str:
         )
     if isinstance(val, param.Parameter):
         return str(val)
-    val_is_sp_real = False
-    if isinstance(val, sp.Basic):
-        val_is_sp_real = val.is_real
-    return str(val) if val_is_sp_real else f"{val:.4g}"
+    return str(val) if is_sympy_real(val) else f"{val:.4g}"
 
 
-def tag_and_coef_to_str(tag: str, val: NUMERICAL_TYPE | Parameter | sp.Basic) -> str:
-    """Returns a string representation with values and tag."""
-    from pepflow import parameter as param
+def coef_times_term_to_str(
+    term_repr: str, val: NUMERICAL_TYPE | Parameter | sp.Basic
+) -> str:
+    """Returns a string representation with coefficient and term."""
 
     # TODO: Check performance
     if isinstance(val, sp.Basic):
         val = val.simplify()
 
-    if isinstance(val, param.Parameter) or is_sympy_expr(val):
-        if isinstance(val, sp.Integer):
-            sign = "+" if val >= 0 else "-"
-            if math.isclose(abs(val), 1):
-                return f"{sign} {tag} "
-            elif math.isclose(val, 0, abs_tol=1e-5):
-                return ""
-        coef = str(val)
-        if coef[0] == "-":
-            coef = coef[1:]
-            sign = "-"
-        else:
-            sign = "+"
-        return f"{sign} {coef}*{tag} "
+    if is_numerical(val):
+        sign = "+" if val >= 0 else "-"
+        if math.isclose(abs(val), 1):
+            return f"{sign} {term_repr} "
+        elif math.isclose(val, 0, abs_tol=1e-5):
+            return ""
+        if isinstance(val, numbers.Number):
+            coef = numerical_str(abs(val))
+            return f"{sign} {coef}*{term_repr} "
 
-    coef = numerical_str(abs(val))
-    sign = "+" if val >= 0 else "-"
-    if math.isclose(abs(val), 1):
-        return f"{sign} {tag} "
-    elif math.isclose(val, 0, abs_tol=1e-5):
-        return ""
+    if is_sympy_expr(val) and not isinstance(val, sp.Rational):
+        coef = sp.latex(val)  # We want LaTeX form (\pi), not plain text (pi)
     else:
-        return f"{sign} {coef}*{tag} "
+        coef = str(val)
+    coef = coef.strip()
+
+    parenthesize_coef = parenthesize_repr(val).strip()
+    if parenthesize_coef != coef:
+        return f"+ {parenthesize_coef}*{term_repr} "
+
+    if coef.startswith("-"):
+        coef = coef[1:].lstrip()
+        sign = "-"
+    else:
+        sign = "+"
+    return f"{sign} {coef}*{term_repr} "
 
 
 def parenthesize_tag(val: Vector | Scalar) -> str:
@@ -240,19 +245,25 @@ def parenthesize_repr(
     # TODO: this function needs to write it properly.
     from pepflow.parameter import Parameter
 
-    tmp_repr = val.__repr__()
+    if is_sympy_expr(val) and not isinstance(val, sp.Rational):
+        tmp_repr = sp.latex(val)  # We want LaTeX form (\pi), not plain text (pi)
+    else:
+        tmp_repr = str(val)
+
     if isinstance(val, sp.Basic):
-        if val.is_real:
-            if val.is_Add:
+        if val.is_Add:
+            return f"({tmp_repr})"
+        if pow_base:
+            if val.is_Mul or val.is_Pow:
                 return f"({tmp_repr})"
-            if pow_base:
-                if val.is_Mul or val.is_Pow:
-                    return f"({tmp_repr})"
-            return str(val)
+        return tmp_repr
+
     if isinstance(val, numbers.Number):
         return f"{val:.4g}"
+
     if pow_exponent:
         return f"{{{tmp_repr}}}"
+
     if isinstance(val, Parameter):
         if op := getattr(val.eval_expression, "op", None):
             if pow_base or op in (Op.ADD, Op.SUB):
@@ -277,8 +288,49 @@ def str_to_latex(s: str) -> str:
     """Convert string into latex style."""
     s = s.replace("star", r"\star")
     s = s.replace(f"{const.GRADIENT}_", r"\nabla ")
+    s = s.replace("⟨", r"\left\langle ")
+    s = s.replace("⟩", r" \right\rangle")
     s = s.replace("|", r"\|")
     s = s.replace("**", "^")
+
+    def _replace_parenthesized_after_token(expr: str, token: str) -> str:
+        """Replace `token(...)` with `token{...}` while preserving nesting."""
+        if not token:
+            return expr
+
+        def _find_matching_paren(open_idx: int) -> int:
+            depth = 1
+            i = open_idx + 1
+            while i < len(expr) and depth:
+                if expr[i] == "(":
+                    depth += 1
+                elif expr[i] == ")":
+                    depth -= 1
+                i += 1
+            return i if depth == 0 else -1
+
+        out: list[str] = []
+        i = 0
+        while (k := expr.find(token, i)) >= 0:
+            out.append(expr[i:k])
+            j = k + len(token)
+            if j >= len(expr) or expr[j] != "(":
+                out.append(token)
+                i = j
+                continue
+            end = _find_matching_paren(j)
+            if end < 0:
+                out.append(expr[k:])
+                return "".join(out)
+            inner = _replace_parenthesized_after_token(expr[j + 1 : end - 1], token)
+            out.append(f"{token}{{{inner}}}")
+            i = end
+
+        out.append(expr[i:])
+        return "".join(out)
+
+    s = _replace_parenthesized_after_token(s, "^")
+    s = _replace_parenthesized_after_token(s, r"\sqrt")
     return rf"$\displaystyle {s}$"
 
 

--- a/pepflow/utils.py
+++ b/pepflow/utils.py
@@ -126,6 +126,7 @@ def is_sympy_expr(val: Any) -> bool:
 
 
 def is_sympy_real(val: Any) -> bool:
+    # NOTE: assumes real-valued SymPy expressions; complex support can be added if needed.
     val_is_sp_real = False
     if is_sympy_expr(val):
         val_is_sp_real = val.is_real

--- a/pepflow/utils.py
+++ b/pepflow/utils.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy as np
 import pandas as pd
+import regex as re
 import sympy as sp
 
 from pepflow import constants as const
@@ -299,36 +300,28 @@ def str_to_latex(s: str) -> str:
         if not token:
             return expr
 
-        def _find_matching_paren(open_idx: int) -> int:
-            depth = 1
-            i = open_idx + 1
-            while i < len(expr) and depth:
-                if expr[i] == "(":
-                    depth += 1
-                elif expr[i] == ")":
-                    depth -= 1
-                i += 1
-            return i if depth == 0 else -1
+        pattern = re.compile(
+            rf"""
+            {re.escape(token)}
+            (?P<par>
+                \(
+                    (?:
+                        [^()]++
+                        | (?&par)
+                    )*
+                \)
+            )
+            """,
+            re.VERBOSE,
+        )
 
-        out: list[str] = []
-        i = 0
-        while (k := expr.find(token, i)) >= 0:
-            out.append(expr[i:k])
-            j = k + len(token)
-            if j >= len(expr) or expr[j] != "(":
-                out.append(token)
-                i = j
-                continue
-            end = _find_matching_paren(j)
-            if end < 0:
-                out.append(expr[k:])
-                return "".join(out)
-            inner = _replace_parenthesized_after_token(expr[j + 1 : end - 1], token)
-            out.append(f"{token}{{{inner}}}")
-            i = end
+        def _repl(m: re.Match) -> str:  # ty: ignore
+            # `ty` cannot resolve `regex.Match`` from third-party `regex`
+            par = m.group("par")
+            inner = _replace_parenthesized_after_token(par[1:-1], token)
+            return f"{token}{{{inner}}}"
 
-        out.append(expr[i:])
-        return "".join(out)
+        return pattern.sub(_repl, expr)
 
     s = _replace_parenthesized_after_token(s, "^")
     s = _replace_parenthesized_after_token(s, r"\sqrt")

--- a/pepflow/vector.py
+++ b/pepflow/vector.py
@@ -457,7 +457,9 @@ class Vector:
                 is_basis=False,
                 eval_expression=ScalarRepresentation(utils.Op.MUL, self, other),
                 tags=[],
-                math_expr=me.MathExpr(f"⟨{repr(self)},{repr(other)}⟩"),
+                math_expr=me.MathExpr(
+                    me.INNER_PROD_STR.format(A=repr(self), B=repr(other))
+                ),
             )
 
     def __rmul__(self, other):
@@ -477,7 +479,9 @@ class Vector:
                 is_basis=False,
                 eval_expression=ScalarRepresentation(utils.Op.MUL, other, self),
                 tags=[],
-                math_expr=me.MathExpr(f"⟨{repr(other)},{repr(self)}⟩"),
+                math_expr=me.MathExpr(
+                    me.INNER_PROD_STR.format(A=repr(other), B=repr(self))
+                ),
             )
 
     def __pow__(self, power):

--- a/pepflow/vector.py
+++ b/pepflow/vector.py
@@ -443,8 +443,8 @@ class Vector:
     def __mul__(self, other):
         if not is_numerical_or_vector(other):
             return NotImplemented
-        expr_self = utils.parenthesize_tag(self)
         if utils.is_numerical_or_parameter(other):
+            expr_self = utils.parenthesize_tag(self)
             expr_other = utils.numerical_str(other)
             return Vector(
                 is_basis=False,
@@ -453,19 +453,18 @@ class Vector:
                 math_expr=me.MathExpr(f"{expr_self}*{expr_other}"),
             )
         else:
-            expr_other = utils.parenthesize_tag(other)
             return Scalar(
                 is_basis=False,
                 eval_expression=ScalarRepresentation(utils.Op.MUL, self, other),
                 tags=[],
-                math_expr=me.MathExpr(f"{expr_self}*{expr_other}"),
+                math_expr=me.MathExpr(f"⟨{repr(self)},{repr(other)}⟩"),
             )
 
     def __rmul__(self, other):
         if not is_numerical_or_vector(other):
             return NotImplemented
-        expr_self = utils.parenthesize_tag(self)
         if utils.is_numerical_or_parameter(other):
+            expr_self = utils.parenthesize_tag(self)
             expr_other = utils.numerical_str(other)
             return Vector(
                 is_basis=False,
@@ -474,12 +473,11 @@ class Vector:
                 math_expr=me.MathExpr(f"{expr_other}*{expr_self}"),
             )
         else:
-            expr_other = utils.parenthesize_tag(other)
             return Scalar(
                 is_basis=False,
                 eval_expression=ScalarRepresentation(utils.Op.MUL, other, self),
                 tags=[],
-                math_expr=me.MathExpr(f"{expr_other}*{expr_self}"),
+                math_expr=me.MathExpr(f"⟨{repr(other)},{repr(self)}⟩"),
             )
 
     def __pow__(self, power):

--- a/pepflow/vector_test.py
+++ b/pepflow/vector_test.py
@@ -26,6 +26,7 @@ import pytest
 import sympy as sp
 
 from pepflow import expression_manager as exm
+from pepflow import math_expression as me
 from pepflow import parameter
 from pepflow import pep as pep
 from pepflow import pep_context as pc
@@ -88,7 +89,7 @@ def test_vector_add_and_mul_tag(pep_context: pc.PEPContext) -> None:
     assert repr(p_add_mul) == "(p1+p2)*0.1"
 
     p_add_mul = (p1 + p2) * (p1 + p2)
-    assert repr(p_add_mul) == "⟨p1+p2,p1+p2⟩"
+    assert repr(p_add_mul) == me.INNER_PROD_STR.format(A="p1+p2", B="p1+p2")
 
     p_add_pow = (p1 + p2) ** 2
     assert repr(p_add_pow) == "|p1+p2|^2"

--- a/pepflow/vector_test.py
+++ b/pepflow/vector_test.py
@@ -88,7 +88,7 @@ def test_vector_add_and_mul_tag(pep_context: pc.PEPContext) -> None:
     assert repr(p_add_mul) == "(p1+p2)*0.1"
 
     p_add_mul = (p1 + p2) * (p1 + p2)
-    assert repr(p_add_mul) == "(p1+p2)*(p1+p2)"
+    assert repr(p_add_mul) == "⟨p1+p2,p1+p2⟩"
 
     p_add_pow = (p1 + p2) ** 2
     assert repr(p_add_pow) == "|p1+p2|^2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "plotly>=6.3.0",
     "pytest>=8.4.1",
     "ruff>=0.12.4",
+    "regex",
     "sympy>=1.14.0",
 ]
 


### PR DESCRIPTION
**utils.py**
- `parenthesize_repr`
  - Refactored `parenthesize_repr` for cleaner branching
  - Aligned `parenthesize_repr` with `coef_times_term_to_str` by switching SymPy expression rendering to `tmp_repr = sp.latex(val)`
    - Updated tests to match the new `sqrt` formatting behavior
- `str_to_latex`
  - Added `_replace_parenthesized_after_token` to convert `token(...)` into `token{...}` while preserving nested parentheses
    - Added exponent parenthesis normalization in `str_to_latex` (`^(`...`)` -> `^{...}`)
    - Added sqrt parenthesis normalization in `str_to_latex` (`\sqrt(`...`)` -> `\sqrt{...}`)
- `coef_times_term_to_str`
  - Renamed the helper function `tag_and_coef_to_str` -> `coef_times_term_to_str`
    - `tag` was no longer an accurate name for string expressions
    - Replaced references in `expression_manager.py` accordingly
  - Refactored `coef_times_term_to_str` to reduce duplicated logic by leveraging `parenthesize_repr`
- Added `is_sympy_real` for concise SymPy-real checks

**Changes to other files**
- `scalar.py`
  - Updated scalar formatting to use `parenthesize_repr(other)` to fix grouping bugs
    - e.g., `(a+b)*v` is no longer rendered as `a+b*v`
- Changed `Vector * Vector` display from `a*b` to `⟨a,b⟩`
  - For consistency with the notation used in `repr_by_basis`
  - Added inner-product LaTeX conversion in `str_to_latex` (`⟨ ⟩` -> `\left\langle \right\rangle`)
  - Removed now-unnecessary extra parenthesization (e.g., `⟨(p1+p2),(p1+p2)⟩` -> `⟨p1+p2,p1+p2⟩`)