### PR TITLE
Add `lyapunov_utils.py` with tests and examples

### DIFF
--- a/examples_lyapunov/appm/appm_example_lyap.ipynb
+++ b/examples_lyapunov/appm/appm_example_lyap.ipynb
@@ -107,7 +107,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x17577c26590>"
+       "<matplotlib.legend.Legend at 0x237fec5f890>"
       ]
      },
      "execution_count": 4,
@@ -478,7 +478,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "V_0: []\n",
+      "V_0:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " []\n",
       "V_1: [A(x_1), A(x_2), y_0-x_1, y_0-x_2, A(x_1)-A(x_2), x_1-x_2]\n",
       "V_2: [A(x_3), y_0-x_3]\n",
       "V_3: [A(x_4), y_0-x_4]\n"

--- a/examples_lyapunov/appm/appm_example_lyap.ipynb
+++ b/examples_lyapunov/appm/appm_example_lyap.ipynb
@@ -1,0 +1,1064 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1c269791",
+   "metadata": {},
+   "source": [
+    "# Accelerated Proximal Point Method (APPM) / Optimal Halpern Method (OHM)\n",
+    "\n",
+    "This code outlines the procedure for Lyapunov function discovery for the\n",
+    "Accelerated Proximal Point Method, an exact optimal method for reducing\n",
+    "the fixed-point residual $\\|x - J_{\\alpha A}x\\|$ with respect to the \n",
+    "initial distance to the solution for a maximally monotone operator A, \n",
+    "introduced in \"Accelerated proximal point method for maximally monotone \n",
+    "operators\" by Donghwan Kim (2021). This method is equivalent to \n",
+    "the Optimal Halpern Method, which was studied in \"On the Convergence \n",
+    "Rate of the Halpern Iteration\" by Felix Lieder (2021)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a10dfb8",
+   "metadata": {},
+   "source": [
+    "## Import the required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd77a040",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pepflow as pf\n",
+    "import numpy as np\n",
+    "import sympy as sp\n",
+    "import matplotlib.pyplot as plt\n",
+    "from itertools import combinations\n",
+    "from IPython.display import display, Math"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0a0719f",
+   "metadata": {},
+   "source": [
+    "## Define the operators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c0b7f1a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = pf.MonotoneOperator(is_basis=True, tags=[\"A\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac3c22c6",
+   "metadata": {},
+   "source": [
+    "## Write a function that generates a PEPContext object associated with APPM/OHM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "245f666e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_ctx_appm(\n",
+    "    ctx_name: str, N: int | sp.Integer, stepsize: pf.Parameter\n",
+    ") -> pf.PEPContext:\n",
+    "    ctx_appm = pf.PEPContext(ctx_name).set_as_current()\n",
+    "    x = pf.Vector(is_basis=True, tags=[\"x_0\"])\n",
+    "    y = x.add_tag(\"y_0\")\n",
+    "    A.set_zero_point(\"x_star\")\n",
+    "    for i in range(N):\n",
+    "        x = A.resolvent(y, stepsize, tag=f\"x_{i + 1}\")\n",
+    "        y = (\n",
+    "            sp.S(i + 1) / sp.S(i + 2) * (sp.S(2) * x - y)\n",
+    "            + sp.S(1) / sp.S(i + 2) * ctx_appm[\"x_0\"]\n",
+    "        ).add_tag(f\"y_{i + 1}\")\n",
+    "\n",
+    "    return ctx_appm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa6b4a78",
+   "metadata": {},
+   "source": [
+    "## Numerical evidence showing that APPM/OHM converges at the rate $\\|\\tilde{A}x_N\\|^2 \\le \\frac{\\|x_0 - x_\\star\\|^2}{N^2}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "252e5596",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x17577c26590>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj0AAAGwCAYAAABCV9SaAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAATT9JREFUeJzt3QeUU9XaxvGHAYbepDdpIiggRRBBERCUy0U/FQtiw66oiGIDFbCD3kvRK6h4FSuKIparCCqCgAWUpkhRioB0ld5l8q13HzNmhgGmZHIyOf/fWsckJ5lkT3Amz+z97r3zhUKhkAAAABJckt8NAAAAiAVCDwAACARCDwAACARCDwAACARCDwAACARCDwAACARCDwAACIQCfjcgnqSkpGjt2rUqUaKE8uXL53dzAABAJtiSg9u3b1eVKlWUlHTo/hxCTwQLPNWrV/e7GQAAIBtWr16tatWqHfJ+Qk8E6+EJv2klS5b0uzkAACATtm3b5jotwp/jh0LoiRAe0rLAQ+gBACBvOVJpCoXMAAAgEAg9AAAgEAg9AAAgEKjpAYA84sCBA9q/f7/fzQBirmDBgsqfP3+On4fQAwB5YA2S9evXa8uWLX43BfBN6dKlValSpRyto0foAYA4Fw48FSpUUNGiRVk8FYEL/bt27dLGjRvd7cqVK2f7uQg9ABDnQ1rhwFO2bFm/mwP4okiRIu7Sgo/9LGR3qItCZgCIY+EaHuvhAYKs6F8/AzmpayP0AEAewJAWgi5fFH4GGN7KZQcOSNOnS+vW2Tik1KaNFIUCdAAAkCg9PdOmTdPZZ5/tdky1dPfee+8d8WumTp2qZs2aqVChQjrmmGP00ksvyU/jx0s1a0rt20uXXOJd2m07DwAAYituQ8/OnTvVuHFjjRgxIlOPX7Fihbp06aL27dtr3rx5uu2223Tttddq0qRJ8oMFmwsukH79Ne35NWu88wQfAABiK26Htzp37uyOzHr22WdVq1YtDRkyxN0+7rjjNGPGDA0bNkydOnVSrIe0eve2aXbe7cLarcpap+0qod9C5WXDkrfdJp1zDkNdAIDEdN5557kRmA4dOmjcuHGKB3Hb05NVX3/9tTp27JjmnIUdO38oe/fuddvRRx7RYDU8kT08/9W1Wq466qGX3W0LQ6tXe48DACAR9e7dW6+88oriSVIiLd5VsWLFNOfstgWZ3bt3Z/g1gwYNUqlSpVKP6tWrR6UtVrQcaa2quMsqWnvYxwEAkCjatWunEiVKKJ4kTOjJjn79+mnr1q2px2rrfomC9ItFhkOPDXEd7nEAgOx9uFodZ7w8T2afL9qvF23t4rx9gQ49th/Hhg0b0pyz2yVLlkxdyTE9m+Vl90ce0WDT0qtVszUFvNvrVDlNT4+dt04lexwAJDorM7AVdG2ySTx/mI8fP14PP/ywL21CbCRM6GnVqpUmT56c5tynn37qzseaFSc/+aRSA07k8FY4CA0fThEzgGB44YUX1KtXL7cUydq1aYf548lRRx0Vd8MxCEjo2bFjh5t6bkd4SrpdX7VqVerQ1BVXXJH6+BtvvFHLly/X3XffrcWLF2vkyJF66623dPvtt/vS/q5dJStWr1o17fBWtaohd97uB4BEZ7/Lx44dq549e7qenvTrp1mvy6233up+d1vosF77Bx54IM1jJk6cqFNPPdXtsm37j5111llatmxZhq9nhbP2GJuoEuncc8/V5ZdfriuvvFJffPGFnnzySbcGnB2//PJLhj1AKSkpeuKJJ9y6bzYycPTRR+vRRx/NcpsO588//9Qtt9zi6krLlSun/v37uw02w+z7sPfH9psqXLiwe81vv/029f6aNWtquP0VHaFJkyZp3sPMvMc7d+50n6nFixd3G3qGZ0InmrgNPd99952aNm3qDtOnTx93fcCAAe72unXrUgOQsenqH330kevdsfV97B/sv//9b8ynq0eyYGM/Sy9O8Ia3imunVny/ncADIPvsA3HnTn+OiA/jzLI/PuvXr6969erpsssu04svvpjmQ928/PLLKlasmGbOnOlCxkMPPeR+l0d+INtngH0uWI9+UlKSmw5toSS9Cy+80G3S+sEHH6Ses00q7fPh6quvdmHHRgCuu+469zlix6Emsdgf14MHD3ZBZOHChRozZkzqhJmstOlw7HsvUKCAZs2a5do2dOhQ99kVZkHlnXfecY+bM2eOC2D2ufbHH39k+XWKHeY9vuuuu1wYfP/99/XJJ5+4qeb2ejlhM6rt32PChAmqVq3aYWdTx0wIqbZu3Wo/ie4y6kqWtB/zUGjx4ug/N4CEtXv37tDChQvdpbNjh/e7xI/DXjuLWrduHRo+fLi7vn///lC5cuVCU6ZMSb2/bdu2oVNPPTXN17Ro0SJ0zz33HPI5N23a5H5X//DDD6nP0bt379T7e/bsGercuXPq7SFDhoRq164dSklJyfDxkW0Jn9+2bVuoUKFCoeeffz5T32f6Nh3udSLvP+6441LbZez7tnNmx44doYIFC4Zef/311Pv37dsXqlKlSuiJJ55wt2vUqBEaNmxYmudt3LhxaODAgZl+j7dv3x5KTk4OvfXWW6n3//7776EiRYoctv2+/yxk4/M7bnt6Ek4Vb4hLcTyeDQDRtGTJEteD0b17d3fbejS6devmanwinXDCCWlu2/CK9c6E/fzzz+45ateu7Sac2JCOieztj2S9ONZbscaWwJfckJoNa2Vlw8pFixa5oSVbWC8jWW3ToZx88slp2mW9UPbc1ltlw2W2o/gpp5ySen/BggV10kknufZlxeHe42XLlmnfvn1q2bJl6v02DGa9c4kmbldkTjg2P33xYkIPgJwpWtQKZfx77SywcGM1K7aHYpgNbVl9zNNPP+3qWMIf5JEsBEQOE9k+jDVq1NDzzz/vnsvua9iwofugzoiVQliZg9X3nHnmmfrxxx/d8FZWHGrWb3bblFtsWC39cKEFpfSO9B77seP5kaT/vqKB0BMr4R96ViQEkBP2YVOsmOKdhR0LHVZfacEjfVHxG2+84SagHMnvv//ueowsXLT5a50P22LoSGzvRSvwtd4eqy2JrNtJTk52PSmHU7duXRd8rF7HnisabcqI1dhE+uabb9xr2xT/OnXquLZ++eWXLmCFA40VMocLrsuXL+/qksJsQV6b+JMVderUcaHI2mLF2mbz5s366aef1LZt25gFklgg9MRKeCVCenoABMCHH37oPjivueaa1B6dsPPPP9/1AmUm9JQpU8bNjho1apQbkrHho759+x7x6y655BLdeeedLpik3wrBhqLsA95mbdlsJRvKsR6TSDZT6p577nGFxBY8bIhp06ZNrtfoqquuylabMmJfawXRN9xwgysc/s9//pM6c8oKj23WmxUZWxstkFgR8q5du9z7ak4//XQ3fGc9TzaTzCb7WGDKiuLFi7vns9ex78tmit13330HvSeZ9fbbb7siafv3HzhwoOsBi8Zjo4HQEyv09AAIEAs11sOSPvCEQ499eH///fdHfB774H3zzTfdlGv7QLQ6k6eeespNwz4ce117HRvWsp6lSBaGevTooeOPP95tU2Q9I+GanEg2a8vqkCxI2PpCFnAsqGW3TRmxaeLWBqvTsbBi+1Vdf/31qffb7DEbhrLp9tu3b1fz5s01adIkFwbDM8ys/TZl3r5nW1wxqz095l//+pdbXsDCk61VdMcdd7idCrLDZmzZYcvM2MytcJCxmWFTpkxJM8X+UI/NLfmsmjlXXyEPsW5B+5/G/qGjtTpzqrFjpYsvlk47Tfrii+g+N4CEtWfPHvchZstyWO8DMs+KkBs0aOACCWLLgpoFRAuMNl3dWCCz69ZTdqTHZvVnIbOf38zeihWGtwAgJmyo5N1333Vrzdx8881+NydhzZ071/Vu2dpBtv6S9azZ9k8WYmxhYBuaiwwx1rNnBeYWUM455xw3PHiox+YWhrf8GN6yzrUYVL4DQBDZ7C0LPo8//nhCTruOBzt37nRT9m1IqmjRom54zoKMLd5oQ5dWbG1T/s844wwXhoxNs7fi8M6dO7sVoe2+Qz02tzC8FavhLVvNtHhx77qNk0b7+QEkJIa3EI/Gjx+vjz/+2BWKh5chWLp0aersr/Ssbsmm9lvt1GuvveaGHbOK4a28xKaYhv8hGOICAORh3/81VGV++OEHt8jioQKPWbBggVt40YazrDjcL4SeWGIGFwAgASQnJ7sZbRZibJabrct0pJBkaxqNHj3aLSdgM8X8QOiJJbaiAAAkgMsuu8zV8xx33HHq0qWLm25/uFlyFnpsOnqzZs100003uc1f/UAhsx8zuOjpAQDkYUcffbRbWycscm2hjNgO8mG2EGJ4ccVYo6cnlujpAQDAN4SeWGKtHgAAfEPoiSUKmQEA8A2hJ5YY3gIAwDeEHr8KmVkTEgCAmCL0+NHTY6szb9vmd2sAAAgUQk8sFS0qlSnjXf/1V79bAwBAoBB6Yi28i+zq1X63BACAQCH0xFr16t4lPT0AAMQUocev0ENPDwAAMUXoiTVCDwDEtZo1a2r48OFRe7527drptttuU2668sorde655+bqayQCQo9fNT0MbwGIoQMHpKlTpTfe8C7tdm5/COfLl0+DBw9Oc/69995z5+PZt99+e8S9pJA3EXpijZ4eADE2frz1Xkjt20uXXOJd2m07n5sKFy6sxx9/XJs3b1ZesG/fPndZvnx5FbXZtkg4hB4/Qw8LFALIZRZsLrjg4M7lNWu887kZfDp27KhKlSpp0KBBh3zMAw88oCZNmqQ5Z0NLNsSUfujmscceU8WKFVW6dGk99NBD+vPPP3XXXXfpqKOOUrVq1TR69Og0z7N69WpddNFF7vH2mHPOOUe//PLLQc/76KOPqkqVKqpXr16Gw1tbtmzRDTfc4F7bglzDhg314Ycfuvt+//13de/eXVWrVnVBqVGjRnrDutMy6aeffnI9X4sXL05zftiwYapTp467fuDAAbcrea1atVSkSBHXzshdyzM7RNekSRP3fkd+X9dee60LeSVLltTpp5+u+fPnp95v19u3b68SJUq4+0888UR99913yssIPX4Nb9kChVu2+N0aAAnMhrB6987476vwOSs1ya2hrvz587ug8p///Ee/5nBI//PPP9fatWs1bdo0DR06VAMHDtRZZ52lMmXKaObMmbrxxhtdMAm/zv79+9WpUyf3gT19+nR9+eWXKl68uP7xj3+k9uiYyZMna8mSJfr0009Tg0yklJQUde7c2X39a6+9poULF7ohO/vezJ49e1wY+Oijj7RgwQI3LHb55Zdr1qxZmfq+jj32WDVv3lyvv/56mvN2+xLrlvurDRbq3n77bff6AwYM0L333qu33norR+/phRdeqI0bN+rjjz/W7Nmz1axZM3Xo0EF//PGHu//SSy91r2vDfXZ/3759VbBgQeVpIaTaunWr/Rpwl7mqbFn7fRMKff997r4OgDxv9+7doYULF7rLrJoyxftVc6TDHhdtPXr0CJ1zzjnu+sknnxy6+uqr3fV3333X/Z4NGzhwYKhx48ZpvnbYsGGhGjVqpHkuu33gwIHUc/Xq1Qu1adMm9faff/4ZKlasWOiNN95wt1999VX3mJSUlNTH7N27N1SkSJHQpEmTUp+3YsWK7nwkey1rg7HHJiUlhZYsWZLp771Lly6hO+64I/V227ZtQ7179z7k4+216tSpk3rbXsveo0WLFh3ya26++ebQ+eefn+H7nf57CGvcuLF7v8306dNDJUuWDO3ZsyfNY6wdzz33nLteokSJ0EsvvRTKCz8Lmf38pqfHD9T1AIgB2+Yvmo/LLqvrefnll7Vo0aJsP0eDBg2UlPT3R5YNNdlQUpj1vJQtW9b1XISHZpYuXep6eqyHxw4b4rKemWXLlqV+nT1HcnLyIV933rx5rrfDemQyYkNPDz/8sHsee357nUmTJmnVqlWZ/t4uvvhiN+z2zTffpPbyWK9L/fr1Ux8zYsQI16NkQ1H2GqNGjcrSa6Q3f/587dixw71n4ffHjhUrVqS+P3369HHDXzZMab1bke9bXlXA7wYENvTMm0foARCTPY6j9bjsOu2009xQU79+/VwdTSQLMqF04282NJVe+mEVq4PJ6JwNBRn7QLeQkH7YyFhwCCtWrNhh2241NIfzr3/9y9XXWP2MBR97PpueHjmEdiRW92T1NGPGjNHJJ5/sLnv27Jl6/5tvvqk777xTQ4YMUatWrVyQs9e1Yb1DOdL7umPHDlWuXFlTbSpfOlYDZaz+x4bYbOjOhsBsSNHact555ymvIvT4gZ4eADHQpo1XRmhFyxnV9djMcbvfHpfbrKfACmnDxcKRAWT9+vXuAzo8ld16V3LKekrGjh2rChUquCLc7DrhhBNcnZAVHGfU22O1PlYgfdlll7nbFrrssccff3yWXsfqZ+6++25XFL18+XLX+xP5Gq1bt9ZNN92Ueu5IvS72vq6L6MLbtm2b68WJfH/sfS9QoECaovH07Hu24/bbb3dts2LxvBx6GN7yA2v1AIgBq7UNT/JJvzRO+LZN8PmrJjdXWS+IfbA/9dRTBy3ct2nTJj3xxBPug9yGcaxXIafstcqVK+cCiRUy2we+9WrceuutWSqqbtu2reupOv/8812xsz2PtW/ixInu/rp167rzX331lRu+s2LqDRs2ZLm9Xbt21fbt210Pj82YstlkYfYaNmvKhs0sUPXv398VFx+O9Ry9+uqr7nv/4Ycf1KNHj9Tia2NDVtZrZLPXPvnkEze8Zt/Dfffd515r9+7duuWWW9x7tnLlShe87DWPO+445WWEHj/Q0wMgRrp2lcaNk6pWPfhvLztv98eKTTMPDz+F2YfoyJEjXdhp3Lixm/VkQzk5ZdPHbabX0Ucf7QKFvY5N+7aanqz2/Lzzzjtq0aKF6+mwHhzrkbFaHnP//fe7XhMbvrMAZ0NV2VkZ2Yaszj77bFdrY4EtkgUp+x66deumli1bumnykb0+GbGhRAtsNsOtS5curk11/poCb6xXbcKECS7QXXXVVa43x3qXLOBYvZQFJHudK664wt1nU/9tFtuDDz6ovCyfVTP73Yh4Yd1/pUqV0tatW3PUHXpEX3xhf95YfLdFGnLvdQDkefYhbb0LtkaLrRGTXfYZPX26V7RsNTw2pBWLHh4gFj8Lmf38pqYnHhYojPMl2QHkfRZw7G8tIMgY3vJDuJ95zx7pr0WgAABA7iL0+KFQIalCBe86dT0AAMQEoccvFDMDABBThB6/EHoAZEH6WU9A0KRE4WeAQma/sFYPgEywLRJsdV3bbNMWnLPb4UX8gCAIhUJuhWtbz8l+Fg63bciREHr87unJwd4pABKf/ZK3Kbq2uq4FHyCoihYt6tZdityDLasIPX4JL/u9cqXfLQEQ5+wvW/tl/+eff6YuigcESf78+d2WGTnt5ST0+B16fvnF75YAyAPCG2ym32QTQOZRyOx36LGdALOwGy8AAMgeQo9fypeXihTxVmRmBhcAALmO0OMXG5dkiAsAgJgh9PiJ0AMAQMwQevxUq5Z3uWKF3y0BACDhEXr8RE8PAAAxQ+jxE6EHAICYIfT4idADAEDMEHriIfTY0vJ79/rdGgAAEhqhx0/lytlmIqzVAwBADBB6/MRaPQAAxAyhx2+EHgAAYoLQ4zfW6gEAICYIPX6jpwcAgJiI69AzYsQI1axZU4ULF1bLli01a9aswz5++PDhqlevnooUKaLq1avr9ttv1549exTXCD0AAAQ79IwdO1Z9+vTRwIEDNWfOHDVu3FidOnXSxo0bM3z8mDFj1LdvX/f4RYsW6YUXXnDPce+99yquEXoAAIiJfKGQzZeOP9az06JFCz399NPudkpKiuu96dWrlws36d1yyy0u7EyePDn13B133KGZM2dqxowZGb7G3r173RG2bds29xpbt25VyZIlFRO//SaVL+9dt16pQoVi87oAACQI+/wuVarUET+/47KnZ9++fZo9e7Y6duyYei4pKcnd/vrrrzP8mtatW7uvCQ+BLV++XBMmTNA///nPQ77OoEGD3JsUPizwxFzZslKxYt71Vati//oAAAREXIae3377TQcOHFDFihXTnLfb69evz/BrLrnkEj300EM69dRTVbBgQdWpU0ft2rU77PBWv379XCoMH6v9WCDQ1uoJz+Batiz2rw8AQEDEZejJjqlTp+qxxx7TyJEjXQ3Q+PHj9dFHH+nhhx8+5NcUKlTIdYNFHr445hjvktADAECuKaA4VK5cOeXPn18bNmxIc95uV6pUKcOv6d+/vy6//HJde+217najRo20c+dOXX/99brvvvvc8FjcCoeepUv9bgkAAAkrLpNAcnKyTjzxxDRFyVbIbLdbtWqV4dfs2rXroGBjwcnEaa323+rU8S7p6QEAIFg9Pcamq/fo0UPNmzfXSSed5NbgsZ6bq666yt1/xRVXqGrVqq4Y2Zx99tkaOnSomjZt6mZ+LV261PX+2Plw+Ilb9PQAABDc0NOtWzdt2rRJAwYMcMXLTZo00cSJE1OLm1etWpWmZ+f+++9Xvnz53OWaNWtUvnx5F3geffRRxb3Imp4DB6yLyu8WAQCQcOJ2nZ54nucfdRZ0ihSR9u+XVq6Ujj46dq8NAEAel6fX6Qkc69lh2joAALmK0BMvqOsBACBXEXriBaEHAIBcReiJF4QeAAByFaEnXrBWDwAAuYrQE489PUyoAwAg6gg98aJmTdtKXtq50/bb8Ls1AAAkHEJPvEhOlmrU8K5T1wMAQNQReuKxrofQAwBA1BF64nU7CgAAEFWEnnjCtHUAAHINoSceQ8/PP/vdEgAAEg6hJ54ce6x3uWQJ09YBAIgyQk+8FTLb5qM7dkjr1vndGgAAEgqhJ96mrYdncC1e7HdrAABIKISeeFOvnndJ6AEAIKoIPfGmfv2/63oAAEDUEHriNfTQ0wMAQFQReuINw1sAAOQKQk+89vSsWiXt2uV3awAASBiEnnhTtqxUrpx3/aef/G4NAAAJg9ATjxjiAgAg6gg98YgZXAAARB2hJx4xgwsAgKgj9MQjhrcAAIg6Qk889/RYIXNKit+tAQAgIRB64lGtWlLBgt6U9V9/9bs1AAAkBEJPPCpQQDrmGO86Q1wAAEQFoSfeh7gWLvS7JQAAJARCT7xq2NC7/PFHv1sCAEAwQ8/u3bu1Zs2ag87/yIdz7oSeBQv8bgkAAMELPePGjVPdunXVpUsXnXDCCZo5c2bqfZdffnlutC+4IkNPKOR3awAACFboeeSRRzR79mzNmzdPo0eP1jXXXKMxY8a4+0J8MEdX3breDK4dO7zNRwEAQI4UyMqD9+/fr4oVK7rrJ554oqZNm6bzzjtPS5cuVb58+XLWEqRlgccWKbSeHhs6rFHD7xYBABCcnp4KFSro+++/T7191FFH6dNPP9WiRYvSnEeUUNcDAIA/oefVV191wSdScnKy3njjDX3xxRfRaxU8hB4AAPwZ3qpWrdoh7zvllFOi0R5EIvQAAOBP6Alblc3C2tKlS6tkyZLZ+tpAhx5boPDAASl/fr9bBABAsEJPzZo1s/w1Vug8cOBADRgwIDsvGdw9uIoUscWRpGXLpGOP9btFAAAEK/SksPN3bCQlSccfL82e7Q1xEXoAAIht6KlVq1a2pqjfdtttuvXWW7PzksEe4rLQY9PWu3b1uzUAAAQr9Lz00kuK1bBY4FHMDACAf6Gnbdu20Xl1HBmhBwCAqGCX9bwSepYskfbs8bs1AAAEq6fnUGyLimOPPVaNGjVSw4YNUy/LlCkTzZcJlqpVpbJlpd9/9+p6TjzR7xYBAJAnRTX0rF27VkuWLNGCBQvcYVtULFy4ULt371aDBg308ccfR/PlgsEKxps0kSZPlubOJfQAABAPoSd//vw6/vjj3XHRRRfp66+/dkHn3Xff1e/WU4HsadrUCz3z5vndEgAA8qyohp7ffvtNkyZN0kcffaS5c+e6ndj/8Y9/6PPPP1f58uWj+VLBYj09htADAED81PQ0btxYd955p9uc1Hp+EMXQM3++rQzpLVoIAACyJF8oFAopSoYOHaoff/zR1fP88ssvql69uitkDh/W6xPPtm3bplKlSmnr1q3xtUfYn39KJUp4s7d++kmqW9fvFgEAkOc+v3Pc07N9+3aVsA9kSX369Elz34oVK1KLml977bW4Dz1xq0ABqVEj6dtvvSEuQg8AAFmW49DTpk0bTZw4UZUqVcpwuwo7zj777Jy+DGyIKxx6LrzQ79YAAJDn5Lg4pGnTpmrZsqUWL16c5vy8efP0z3/+M6dPj8gZXMamrQMAgNiHntGjR+vKK6/UqaeeqhkzZuinn35y09Vt5haFzFHEDC4AAPyfvfXggw+qUKFCOuOMM3TgwAF16NDBrdFz0kknRePpYaymxxYqXLdO2rDBpsr53SIAAILV07Nhwwb17t1bjzzyiFuUsGDBgq7nh8ATZcWLS8ce612ntwcAgNiHHitUnjZtmt5++23Nnj1b77zzjq6//nr961//yulT41BDXNT1AAAQ+9Dz4osvutWXu3Tp4m7btPQpU6Zo2LBhuvnmm3P03CNGjFDNmjVVuHBhVyw9a9aswz5+y5Yt7jUrV67shtts89MJEyYoYTRr5l3Onu13SwAACF5Nz8UXX3zQuWbNmumrr75S586ds/28Y8eOdev+PPvssy7wDB8+XJ06dXIbmlaoUOGgx+/bt8/VFNl948aNU9WqVbVy5UqVLl1aCaNFC+/Spq4DAAD/VmROb/PmzSpTpky2vtaCTosWLfT000+72ykpKW6F5169eqlv374HPd7CkQ2p2dR5qyvKjL1797ojckVHe424W5E5bNs2yUKc/ZNZMXMG4Q8AgKDZlskVmZNy68WtzsdWYc4O67Wx+qCOHTumnktKSnK3bVZYRj744AO1atXKDW/ZHmC27cVjjz3mZpMdyqBBg9ybFD4s8MQ1+4esV8+7Tm8PAABZkunQc+ONN2r69OkHnV+1apULHA899JC6du2q2rVru96ddu3a6d5771V2d2u3sGLhJZLdXr9+fYZfs3z5cjesZV9ndTz9+/fXkCFD3KyyQ+nXr59LheFj9erVinsMcQEAkLs1Pc2bN9cVV1zh9tMyp59+uubPn++GsKyXxKarW++KhaAXXnjBrdUTy54TG/6yep5Ro0a5RRFtccQ1a9a4Ia+BAwdm+DVW7GxHnmKh59VXCT0AAORWT8/MmTN16aWXpt621Zet98d6Ryz4fPnll3ruueeUL18+t0ZPTgJPuXLlXHCxNYAi2e2M9vgyNmPLZmtFrgJ93HHHuZ4hGy5LGJE9PblXjgUAQHBDj83Guvbaa9OEIBvushoa23oimpKTk11PzeTJk9P05Nhtq9vJyCmnnKKlS5e6x4VZuywM2fMl1Fo9tuv6pk02tuh3awAASLzQM3jwYN13331pNhq1YmXbZ8umklv42bhxY9QaZtPVn3/+eb388statGiRevbsqZ07d+qqq65y99tQm9XkhNn9f/zxh1sd2sLORx995AqZc7pWUNwpXFg64QTvOkNcAABEP/ScffbZev311w86f8kll+jHH390xcsNGjRwPS2HmzGVWd26ddO///1vDRgwQE2aNHG7tk+cODG1uNlqh9bZPlR/seG0SZMm6dtvv9UJJ5ygW2+91QWgjKa353kUMwMA4O86PTaD6vbbb3fTyu+++27Xy1KkSBEl2jx/373wgmRDje3bS59/7ndrAAAI3jo9Nl39/fffd+vzjB492t1GLvb02HYUETVMAABAsV2c8Mwzz3TT2e+5557ceHocf7xUtKi3QvOiRX63BgCAxN17y+ppMsMWK4x8rO2DFdfDRnmFzd466SRp6lTJVqhu0MDvFgEAkJihx3Y+zypbv8cWCbTCZERB69Ze6PnqK6++BwAARD/0RK6FAx9Dj7HQAwAAcif01KpVy/XcZNVtt93mppIjCk4+2btcssQ2K7NlrP1uEQAAiRd6XnrpJcVqWAyHULasVL++tHix9M030lln+d0iAAASL/S0bds2+i1B9oa4LPTYEBehBwCA2E9ZR4xQ1wMAQKYRehIh9MyaJe3f73drAACIa4SevKxePalMGWn3bmn+fL9bAwBAXCP05GVJSVKrVt51hrgAADgsQk+iDHHNmOF3SwAASPzQM336dF122WVq1aqV1qxZ4869+uqrmsEHce5r08a7nDZNCoX8bg0AAIkbet555x116tRJRYoU0dy5c7V371533rZ3f+yxx6LRRhyO7cFVqJC0YYO3UCEAAMid0PPII4/o2Wef1fPPP6+CBQumnj/llFM0Z86cnD49jqRw4b/rer74wu/WAACQuKFnyZIlOu200w46X6pUKW3ZsiWnT4/MCC8WaRuQAgCA3Ak9lSpV0tKlSw86b/U8tWvXzunTIzPatfu7p4e6HgAAcif0XHfdderdu7dmzpzpNiFdu3atXn/9dd15553q2bNnTp8emdGypZScLK1bJ/38s9+tAQAgcfbeitS3b1+lpKSoQ4cO2rVrlxvqKlSokAs9vXr1ik4rcXhFini7rtsMLuvtOfZYv1sEAEDi9fRY7859992nP/74QwsWLNA333yjTZs26eGHH45OC5E51PUAAJC7oWf37t2uhyc5OVnHH3+8KlasqP/+97/65JNPcvrUyArqegAAyN3Qc8455+iVV15x1222VsuWLTVkyBB3/plnnsnp0yOzbHjLlgywxSGXLfO7NQAAJF7osbV42vy1KvC4ceNcT8/KlStdEHrqqaei0UZkRtGiXvAxkyf73RoAABIv9NjQVokSJdx1G9Lq2rWrkpKSdPLJJ7vwgxjq2NG7/PRTv1sCAEDihZ5jjjlG7733nlavXq1JkybpzDPPdOc3btyokiVLRqONyKwzzvi7p+fAAb9bAwBAYoWeAQMGuOnpNWvW1EknneQ2HQ33+jRt2jQabURmtWhhS2FbcZX03Xd+twYAgMQKPRdccIFWrVql7777zvX0hNm6PcOGDcvp0yMrChSQTj/du84QFwAA0V2cMLwVha3TY707+/btSz2/fv161a9fPxovgawMcb37rhd67r/f79YAAJA4oWf58uU677zz9MMPP7iFCkN/rRFj180Bakv8qev5+mtpxw6peHG/WwQAQFzI8fCW7btVq1YtV7hctGhR/fjjj5o2bZqaN2+uqawOHHt16kg1a0r793sLFQIAgOiEnq+//loPPfSQypUr56aq23Hqqadq0KBBuvXWW3P69Mgq62EL9/ZQ1wMAQPRCjw1fhdfpseBju6ybGjVqaMmSJTl9emRHOPREFJYDABB0Oa7padiwoebPn++GuGwLiieeeMLtwzVq1CjVrl07Oq1E1kNP/vzS4sXSihVSrVp+twgAgLzf03P//fcrJSXFXbdhrhUrVrhtKSZMmMA2FH4pXVo65RTv+kcf+d0aAAASo6enU6dOaVZnXrx4sZu+XqZMmdQZXPBBly7StGnShx9Kt9zid2sAAMj7PT0ZOeqoowg8fjvrLO/SZtDt3Ol3awAAyPuhx2Zpvfjiiwedt3OPP/54Tp8e2XXccd7U9b172XUdAIBohJ7nnnsuw1WXGzRooGeffTanT4/ssp42G+Iy1PUAAJDz0GNbTVSuXPmg8+XLl9e6dety+vTIiXDomTBB+mulbAAAgirHoad69er68ssvDzpv56pUqZLTp0dOtG8vFS0q/fqr9P33frcGAIC8PXvruuuu02233ab9+/fr9L92+J48ebLuvvtu3XHHHdFoI7KrcGHb7l763/+kDz6QGjf2u0UAAOTd0HPXXXfp999/10033ZS6w3rhwoV1zz33qF+/ftFoI3Li3HO90GM7r/fv73drAADwTb5QeFv0HNqxY4cWLVqkIkWKqG7duipUqJDymm3btqlUqVLaunWrSpYsqYSwaZNUqZJkC0ja6sw2owsAgASS2c/vqK3TU7x4cdfTk1cDT8IqX1467TTvuvX2AAAQUFFdnLBz585as2ZNNJ8S0XDeed4loQcAEGBRDT1RGilDboWeGTOkDRv8bg0AAImzDQXiTPXqUvPm3lo9NosLAIAAynHoWbVqVWoPj63OXLFiRXfdztl9iLPenvHj/W4JAAB5c/ZW/vz53crLFSpUSHPeprHbuQMHDiivSMjZW2GLF3v7cRUs6A1xlSnjd4sAAMhbs7csM2W0o7pNYbf1ehAnbH+0Ro2k/fspaAYABFK2Fyfs06ePu7TA079/fxW17Q7+Yr07M2fOVJMmTaLTSkTHxRdLP/wgvfmmdPXVfrcGAIC8EXrmzp2b2tPzww8/KDk5OfU+u964cWPdeeed0WkloqNbN+m++2yfEG+I66/6KwAAgiDboWfKlCnu8qqrrtKTTz6ZeDUwiahOHemkk6RZs6Rx46Sbb/a7RQAAxEyOa3pGjx5N4MlrQ1zGhrgAAAiQHIee3bt3a9euXam3V65cqeHDh2vSpEk5fWrkhosuskIsb6HC1av9bg0AAHkn9Jxzzjl65ZVX3PUtW7aoZcuWGjJkiM4991w988wz0Wgjoqlq1b/34ho71u/WAACQd0LPnDlz1KZNG3d93LhxbnFC6+2xIPTUU0/l6LlHjBihmjVruqnvFqZmWS1KJrz55ptuVpkFL2Sge3fv0sIqW4cAAAIix6HHhrZKlCjhrn/yySfq2rWrkpKSdPLJJ7vwk11jx4510+IHDhzogpXNBuvUqZM2btx42K/75Zdf3KyxcBDDIWZxFSrkTV+fN8/v1gAAkDdCzzHHHKP33ntPq1evdnU8Z555pjtv4SQnBc5Dhw7Vdddd52aHHX/88Xr22WfdWkAvvvjiIb/G1ge69NJL9eCDD6p27drZfu2EV7q0jUt6119+2e/WAACQN0KP9cRYz4oNQ9kQVKtWrVJ7fZo2bZqt59y3b59mz56tjh07/t3QpCR3++uvvz7k1z300ENu64trrrkmU6+zd+9et3R15BEYPXp4l6+/bm+4360BACB+1+kx+/fv18iRI/XZZ5+5IS4bggrr0KGDzgtvcplFv/32m+u1CW9eGma3F9seUhmYMWOGXnjhBc3LwnDNoEGDXK9QIFmPXKVK0vr10scf/93zAwBAgspRT0/BggX1/fffq3Llyq5Xx3pjwk466STVt/2eYmD79u26/PLL9fzzz6tcuXKZ/rp+/fq5zcnChw3RBUaBAtJll3nXGeICAARAjoe3LrvsMtfDEk0WXGz39g22VUIEu13JeifSWbZsmStgPvvss1WgQAF32OyxDz74wF23+zNSqFAhV3cUeQRKeIjrww+lTZv8bg0AAPE7vGX+/PNPV1xsQ1wnnniiihUrdlBBclbZ3l32XJMnT06ddp6SkuJu33LLLQc93nqUbP+vSPfff7/rAbItMqpXr57lNgRCw4ZS8+bSd995vT3slQYASGA5Dj0LFixQs2bN3PWffvopzX22Vk522XT1Hj16qHnz5m6ozFZ53rlzp5vNZa644gpVrVrV1eXYOj4N7QM8QmmboeQ+19OeRzo33OCFnueeszfdKsb9bhEAAPEZesIbj0Zbt27dtGnTJg0YMEDr169XkyZNNHHixNTi5lWrVqWpIUIO9uK64w5p6VLp88+liBlzAAAkknyhEEvyhtmU9VKlSrmi5kDV99hu6yNHShdcIL39tt+tAQAgVz6/oxJ6bM8tK2ZetGiRu22LCdpaOdaAvCSwoef77yVbbsBmdK1aJVWu7HeLAACI+ud3jseHvvvuO9WpU0fDhg3TH3/84Q67buds+wjkASecILVubVXp0mFWvAYAIC/LcU+P7XFlW1HYGjk2PTw8o+vaa6/V8uXLNW3aNOUVge3pCW8+alPYa9SwNQCk/Pn9bhEAAPE1vFWkSBHNnTv3oIUIFy5c6GZe2YakeUWgQ8/u3VLVqtLmzdL//ieddZbfLQIAIL6Gt+zJbSZVera6cXj3deQBRYpIV1/tXR8+3O/WAAAQdUnRmFpuRctjx451QceON9980w1vde/ePTqtRGz06uWt0zN5slfcDABAAsnxOj3//ve/3SKEtlig1fKE9+Tq2bOnBg8eHI02Ilasnuf8871p68OGSaNH+90iAACiJts1PStWrFCtWrVSb1vtTniPK5u5VbRoUeU1ga7pCfvmG6lVK9sLRFq50tuJHQCAINf0WLCx0HP11Vfrtdde0+bNm9WoUSN35MXAg7+cfLJ37NsnPfOM360BACBqsh16Pv/8c7c3lk1Lv+6663T00Uerbt26uuGGG1xNT/od0pGH2B5cxlZptlldAAAkgKisyLxnzx599dVXmjp1qjtmzZql/fv3u2nsP/74o/IKhrf+YrVZxxzjDW+NGiVdd53fLQIAID62oQjbt2+fvvzyS3388cd67rnntGPHDh04cEB5BaEnwtCh3kakFn4WL2axQgBAsNfpsZBjKy4/+OCDat++vUqXLq0bb7zR1fc8/fTTrtgZedT110tly3q7r7/1lt+tAQAgx7Ld03P66adr5syZrpi5bdu2bjsKu6ychzerpKcnnUcfle6/X2rQwFu3x9bwAQAgaD0906dPV9myZV346dChg84444w8HXiQgVtukUqVkqwu6/33/W4NAAA5ku3Qs2XLFo0aNcpNT3/88cdVpUoVN139lltu0bhx47Rp06actQz+s8BjqzSbRx6Rolf+BQBAzEWtkHn79u2aMWOGpkyZ4mZwzZ8/301hX7BggfIKhrcy8NtvUs2a0s6d0oQJUufOfrcIAAB/NhwNK1asmI466ih3lClTRgUKFNCiRYui9fTwS7lyUs+e3vUHH6S3BwCQZ2U79KSkpLj1eJ544gl17tzZzdxq3bq1Ro4cqUqVKmnEiBFu4UIkAJu6bqtsz5wpffCB360BACC2w1vWfbRz504XcGy6uh3t2rVz21PkVQxvHca990qDBnkzuebPZ90eAEBwFie0xQct6Bx77LFKFISew9i8Wapd2yrYpVdekS6/3O8WAQAQm5oe22MrkQIPjqBMGemee7zrAwd6G5ICAJCHsNocMu/WW6VKlSRbafv55/1uDQAAWULoQeZZMXP//t71hx+2dQr8bhEAAJlG6EHWXHuttwnphg3S4MF+twYAgEwj9CBrkpOlf//buz5kiDfUBQBAHkDoQdb93/9JHTpIe/dKd9/td2sAAMgUQg+yLl8+adgwb9f1ceOkL77wu0UAABwRoQfZ06iRdP313vXbbpMOHPC7RQAAHBahB9n30EPeTuzz5tlqlX63BgCAwyL0IPvKl5ceecS73q+ftG6d3y0CAOCQCD3IGduBvUULWwNcuv12v1sDAMAhEXqQM7bxqA1tWVHz2LHSxIl+twgAgAwRepBzTZtKvXt712+6Sdq1y+8WAQBwEEIPolfUXL26t1ihbUgKAECcIfQgOooXl0aO/Hul5q++8rtFAACkQehB9Jx1ltSjhxQKSVdeyTAXACCuEHoQXcOHS1WrSj//LN13n9+tAQAgFaEH0VW6tPTf/3rXn3ySLSoAAHGD0IPo+8c/pGuv9Ya5rrhCB37foqlTpTfekLtkxwoAgB8IPcgdVsxcp460apUmVL9e7duHdMklUvv2Us2a0vjxfjcQABA0hB7kjpIlNeX6N7RfBXT27rd1jV5IvWvNGumCCwg+AIDYIvQgV9gQ1hX/aaF79Zi7/ZRuVX0tctdt1MuwOTsAIJYIPcgV06dLv/4qDdEd+kRnqKh26y1dpKLamRp8Vq/2HgcAQCwQepArwhuuh5SkK/SK1quiGmmBRul6dzb94wAAyG2EHuSKypX/vr5BlXSh3nb1PZdqjG7VUxk+DgCA3EToQa5o00aqVk3Kl8+7PUNtdIeGuOs25NVWX7ituuxxAADEAqEHuSJ/fm9tQhMOPv9RL72mS1VABzRWF+nZ/mvc4wAAiAVCD3JN167SuHHerhSefLpeo/RjwcaqqI3656hz2Z8LABAzhB7kevD55RdpyhRpzBhpwpSiqv/jeKlsWem776TLLmPeOgAgJvKFQuFVU7Bt2zaVKlVKW7duVcmSJf1uTmKbMUPq0EHat0/q08dbwRkAgFz8/KanB/449VTppZe860OHSiNH+t0iAECCI/TAP927S4884l3v1Uv66CO/WwQASGCEHvjr3nulK6+UUlK8DbmmTfO7RQCABEXogb9sPvuoUVKXLtKePdJZZ0mzZ/vdKgBAAiL0wH8FC0pvvy21bStt3y794x/SIm9zUgAAooXQg/hQpIj0wQdS8+bSb79JZ5whrVjhd6sAAAkkrkPPiBEjVLNmTRUuXFgtW7bUrFmzDvnY559/Xm3atFGZMmXc0bFjx8M+HnHIphl+/LF0/PHSmjVSu3bSsmV+twoAkCDiNvSMHTtWffr00cCBAzVnzhw1btxYnTp10saNGzN8/NSpU9W9e3dNmTJFX3/9tapXr64zzzxTa+zDE3lHuXLSZ59J9epJq1Z5Q14//+x3qwAACSBuFye0np0WLVro6aefdrdTUlJckOnVq5f69u17xK8/cOCA6/Gxr7/iiisy9ZosThhH1q/3Fi9cuNDbit2WdLYgBABAIi1OuG/fPs2ePdsNUYUlJSW529aLkxm7du3S/v37ddRRRx3yMXv37nVvVOSBOFGpkhd0GjaU1q3zenx++MHvVgEA8rC4DD2//fab66mpWLFimvN2e731AGTCPffcoypVqqQJTukNGjTIJcPwYT1JiCMVKnjBp3FjacMGqU0bafp0v1sFAMij4jL05NTgwYP15ptv6t1333VF0IfSr18/1xUWPlavXh3TdiKTNT4WfE45Rdq61ZvV9d57frcKAJAHxWXoKVeunPLnz68N9td9BLtdyYY9DuPf//63Cz2ffPKJTjjhhMM+tlChQm7sL/JAHCpTRvr0U+n//s/GJKXzz/cWNAQAIK+HnuTkZJ144omaPHly6jkrZLbbrVq1OuTXPfHEE3r44Yc1ceJENbf1XpBY6/i884507bXelhU33GBjmFax7nfLAAB5RFyGHmPT1W3tnZdfflmLFi1Sz549tXPnTl111VXufpuRZcNTYY8//rj69++vF1980a3tY7U/duzYscPH7wJRVaCA18MzYIB3+4knpPPO81ZxBgAgr4aebt26uaGqAQMGqEmTJpo3b57rwQkXN69atUrrbFbPX5555hk36+uCCy5Q5cqVUw97DiTYXl0PPii9/rqNT0r/+59X7/PLL363DAAQ5+J2nR4/sE5PHjNzpnTuud6aPuXLe8NfNsMLABAo2/LyOj1AprRsKdlWI02aSJs2Se3bWyW7RI4HAGSA0IO8zdZWmjFD6t7dK2q+6y6vzmfLFr9bBgCIM4Qe5H3Fink1PiNH2tQ/6f33pWbNpNmz/W4ZACCOEHqQOAXOPXtKX34p1awprVghtW4tDR3qTXEHAAQeoQeJxdZnmjNHOucc28RNuuMObxVnVtsGgMAj9CAxV3B+913pueekokWlzz+XbHXuN97wu2UAAB8RepC4w13XXy/Nm+fN8rLC5ksukS66yNu8FAAQOIQeJLa6db3ZXQ88IOXPL739tnTccdJLLzG1HQAChtCDxGfbVwwc6K3p07SptHmzZNuZnHmmtHy5360DAMQIoQfBYdPYLfg8/rhUuLD02WdSw4bSI49Ie/b43ToAQC4j9CB4vT533y19/73Urp20e7fUv7/UoIH0wQcMeQFAAiP0ILi1Pjara8wYqUoVb5jLprn/85/STz/53ToAQC4g9CDYM7xs+4olS6S+faWCBaWJE70hr9tu8/bzAgAkDEIPULy4NGiQ9OOPXk/P/v3Sk09Kdep49T47d/rdQgBAFBB6gMghr48+kj791Ct63r7dq/ex8PPMM14YAgDkWYQeIL2OHaVvv5XefFOqXdtbzPCmm7xQZKs8793rdwsBANlA6AEykpQkdesmLVokPf20VLGitHKldOON0jHHeOeY5g4AeQqhBzic5GTp5pu9Xdutzsdmev36q9Srl1SrljRsmLRjh9+tBABkAqEHyIwiRaRbb5WWLZNGjpSqV5fWr5f69JGqVZPuuccLQxk4cECaOtXb79Qu7TYAIPYIPUBW2ErOPXtKS5dKo0Z5dT5bt0pPPOH1/Fx6qTR7durDx4+XataU2rf39ju1S7tt5wEAsZUvFGIJ2rBt27apVKlS2rp1q0qWLOl3c5AXpKR4M76GDvW6ccLatNGs5jfptGHnaa8KHbQ8kBk3TuraNcbtBYAAf34TeiIQepAj1sNjNT5jx0p//ulObVR5vaBrNErX6xfVShN8bFTMSoVs83cAQO5/fjO8BUTLiSdKr73mkswvPQZqjaqogjapnwZrmepogjrrXL2rgtrntvhavVqaPt3vRgNAcBB6gGirVk1fd3pANbRS52m8JulMJSmkzpqod9VVa1VFT6mXmutbrVtLRysAxAqhB8gFlStLB1RA7+k8/UOTVEdLNVj3uN6fcvpdvfS0vtVJ+r97G0iDBx9y5hcAIHqo6YlATQ+ixaal2yytNWvkhrLCknRAHfWZeuhldc33rgqH9vxd5NOmjXThhdL553upCQCQKdT0AD6y4mRbyzBytpZJUX59mq+TLss3Rp+8skH673+9sGPJaNo0b9HDqlWldu2kESO8tYAAAFFBT08EenoQbbYeT+/eaUevbF3D4cPTTVdftcqbw/7229I33/x93hLTaadJ554rnX22t/kpACANpqxnA6EHuTXUZbO01q3zRq2sY+ew09TDAeitt6SZM9Ped9xxXvj5v/+TTj6Z+e4AIEJPthB6EHdsk9N335X+9z9v+Ouv9X+ccuWkf/5T6txZ6tBBKl/ez5YCgG8IPdlA6EFc27JFmjjRC0ATJni3IzVrJp15pne0bi0VSrsSNAAkKkJPNhB6kGfs3y99+aW3BcYnn0jff5/2/qJFpbZtpTPO8C4bN2YoDEDCIvRkA6EHeZYVDH32mfTpp14I2rAh7f32//Opp3oByAqjbfXoggX9ai0ARBWhJxsIPUgI9iP9ww9eAJo8WZoxQ9q+/eCeIBsCsxBkly1aSCVK+NViAMgRQk82EHqQsNPH5s3zCqG/+MKbSvbHH2kfk5QkNWjgzQizo2VLb6aYnQeAOEfoyQZCDwIhJUX68UcvBNlh6wLZNPn07GfgpJO8ENS8udS0qbfIUORqi7k1bR8AsoDQkw2EHgSWpRFbE8gCkB3ffivt2nXw48qW9WaJWQCySztswcTD9AhltEBjtWreitVpFmgEgGwi9GQDoQf4i60HtGCBF4AsDM2Z4/UOWZdNelYL1KSJF4QaNZIaNvSGykqUcIHnggvS7j9mwp1FtgYjwQdAThF6soHQAxzGnj1eELIAZMfcudL8+dLevRk+PFSjhiZvaKjv9jTUAnnHYtXXXhVODT7W47NiBUNdAHKG0JMNhB4gGz1Cixd7IciKpS0U2WHDZRk4oCT9rLou/CxRPXfc8lQ9Netez1thGgCygdCTDYQeIEp+/12fPfmjxj8c7uNZoEb6QWWUbhXpSEcdJdWr5x3HHvv39WOOYXVpAIdF6MkGQg8QPVOnSu3bR54JqbLWuQDk9fF4R5sKS1R44+pDP1F4HKx27YwP23MsGzPKACQOQk82EHqA6LGa55o1pTVrDi5kPqimZ89OaelSacmSg4/0CyumV6zYwUHo6KP/PsqUIRQBCW4boSfrCD1AdIVnb5nI3zSZnr1lX7Rxo5eMli8/+LB58Ef6FWarT4cDkK0zlP66XRb2iqtzC+sUAbmL0JMNhB4g+jJap8dyxvDhUZiubjPHVq48OAytXu0tuGiBKTNsiMwaZYmkSpW/j8jbFSpkK6mwThGQ+wg92UDoARKsp8Om2VvasABkRzgMRV7fuTNzz2ULMFasmHEoqlTJC0Xhw4bcInq6WKcIyF2Enmwg9AABY7/+Nm/2wo8VH1kqW7v27yN8e/16b/uOzCpaVKGKFTV3TQX9uq+CNso7Nqhi6vVNqqACVSro2xXllD+ZsS4gJwg92UDoAXDIriobKosMQpGH3WfHhg1e71IWhPLlUz6brm9bfGTlyOU6pGijrgnx8PldIFdbAQCJwD6d7ZPajsOxvyF37HAB6JPXNmrkAxv+6tf5+6iov8+V1e9Ksq/5/XfvyAor0E4fhCw8lS7992Ez1yJvh4/kZMUSdU2IF4QeAIgWK9axvchKlFBy2zp6/wgPz68/Ne2d39T62N/+Dj5HOv74w+s2sQ1h7bDapKwqUiTjMJQ+JNlfzHbY95T+MpPB6VB1TTaaaOeDUtdET1d8YHgrAsNbAHxZpygrH35WW7RtW8aByOqTtmw59LF1a/S+QVsl+1CB6K/LlOIl9fDwElq1taS2qaS2q0Tq5U4V004VV+mqxbRwRRHlL5ikREVPV+6jpicbCD0A4mqdotxIYhaYDheMwsHJLm1hSHu8HeHrWaxZytJwXfHi3sy38JHT23ZY7ZOPi1Mygy82PV2Enmwg9ADIU+sU+WH/fi8AhUPQYS6XztmmWZ9vl/XzlFDaS+vnKaZdsWmzDedFHhawsnMuM4+xYb+/Ek24ty/y3z4qvX15zPgY9HQRerKB0AMgNwS1nuPg/dfSyqcUFdUuTXpnp05pstNbM8kKwe1yZw5v28KVfrAkY71LhQppb1JhrfujkPaosPbq0Jcd/llYlWsWSv26TF8e7r6I8OWn8THq6SL0ZAOhBwDyQF1TZvz5p1fovXv330f62xmdy8xjMjqXlXWcYqVgQS/8ZPcomLOvP5A/WedcmKzVG5O1T96xQ8XdHMZo//szZR0A4Cv7ILMhDPtL3z7gMqprsmG+XOn1KlDg79lnuc2+MRv2Cwch62Xau1ffTt+jm6/bq8Lao0I69OUt1+xR7ap7vXqpvRGXkdczc7lvX9p2WZvsyOyq41Fm/6wfpjs3Q6eojWakvm02+dB6Qdu1U0wQegAAucaGLmwII6Oajjxb15SeJbhwD4dN9f9Ls2OkdQ8euafrX8/9lRByynqbLPhYALKwY9djdew/+PW2/b5Pf6wP9/F4h/X0pGfDvrFC6AEA5CoLNuecE7y6ppj3dNn+cFbTEyerdc85Qk1X2JHW/IymuF4YYcSIEapZs6YKFy6sli1batasWYd9/Ntvv6369eu7xzdq1EgTJkyIWVsBAIdmH+w2hNG9u3eZ6IEnfU9X1appz1sPT6JPV2/Txvs+D1VPbedtJqM9TkEPPWPHjlWfPn00cOBAzZkzR40bN1anTp200fa3ycBXX32l7t2765prrtHcuXN17rnnumPBggUxbzsAAGEWbH75RZoyRRozxru04t1EDjyRPV0mffDJ9ZquvDZ7y3p2WrRooaefftrdTklJUfXq1dWrVy/17dv3oMd369ZNO3fu1Icf/l02dfLJJ6tJkyZ69tlnM3yNvXv3uiOy+tteg9lbAADknbWqMjt7Ky57evbt26fZs2erY8eOqeeSkpLc7a+//jrDr7HzkY831jN0qMebQYMGuTcpfFjgAQAAidnTFZeFzL/99psOHDigihW9ufxhdnvx4sUZfs369eszfLydP5R+/fq5IbT0PT0AACD6NV1+i8vQEyuFChVyBwAASHxxObxVrlw55c+fXxs2bEhz3m5XqlQpw6+x81l5PAAACJa4DD3Jyck68cQTNXny5NRzVshst1u1apXh19j5yMebTz/99JCPBwAAwRK3w1tWa9OjRw81b95cJ510koYPH+5mZ1111VXu/iuuuEJVq1Z1xcimd+/eatu2rYYMGaIuXbrozTff1HfffadRo0b5/J0AAIB4ELehx6agb9q0SQMGDHDFyDb1fOLEianFyqtWrXIzusJat26tMWPG6P7779e9996runXr6r333lPDhg19/C4AAEC8iNt1evzALusAAOQ9eXqdHgAAgGgj9AAAgEAg9AAAgECI20JmP4TLm2xsEAAA5A3hz+0jlSkTeiJs377dXbIVBQAAefNz3AqaD4XZWxFsAcS1a9eqRIkSyhfe9z4Kwnt6rV69OrCzwoL+HgT9+zdBfw+C/v2boL8HfP/bcu37tyhjgadKlSpplrNJj56eCPZGVatWLdee3/6Rg/g/eqSgvwdB//5N0N+DoH//JujvAd9/yVz5/g/XwxNGITMAAAgEQg8AAAgEQk8MFCpUSAMHDnSXQRX09yDo378J+nsQ9O/fBP094Psv5Pv3TyEzAAAIBHp6AABAIBB6AABAIBB6AABAIBB6AABAIBB6ctm0adN09tlnu1UibZXn9957T0ExaNAgtWjRwq1wXaFCBZ177rlasmSJguSZZ57RCSeckLoYV6tWrfTxxx8rqAYPHux+Dm677TYFxQMPPOC+58ijfv36CpI1a9bosssuU9myZVWkSBE1atRI3333nYKiZs2aB/0/YMfNN9+sIDhw4ID69++vWrVquX//OnXq6OGHHz7iPlm5gRWZc9nOnTvVuHFjXX311eratauC5IsvvnA/1BZ8/vzzT917770688wztXDhQhUrVkxBYCt82wd93bp13Q/4yy+/rHPOOUdz585VgwYNFCTffvutnnvuORcCg8b+rT/77LPU2wUKBOdX7+bNm3XKKaeoffv2LvCXL19eP//8s8qUKaMg/b9vH/xhCxYs0BlnnKELL7xQQfD444+7PwDt95/9LFjgveqqq9wKyrfeemtM2xKcnzyfdO7c2R1BNHHixDS3X3rpJdfjM3v2bJ122mkKAuvli/Too4+6H/5vvvkmUKFnx44duvTSS/X888/rkUceUdBYyKlUqZKCyD7wbL+l0aNHp56zv/iDxIJeJPtDyHo72rZtqyD46quv3B97Xbp0Se35euONNzRr1qyYt4XhLcTM1q1b3eVRRx2lILK/9N58803X+2fDXEFiPX72C69jx44KIuvZsCHu2rVru/C3atUqBcUHH3yg5s2bu14N+6OnadOmLvwG1b59+/Taa6+53v9obmwdz1q3bq3Jkyfrp59+crfnz5+vGTNm+NIhQE8PYraDvdVxWDd3w4YNFSQ//PCDCzl79uxR8eLF9e677+r4449XUFjQmzNnjuviD6KWLVu6Xs569epp3bp1evDBB9WmTRs3xGH1bolu+fLlrnezT58+bojb/j+wIY3k5GT16NFDQWN1nVu2bNGVV16poOjbt6/bYd1q2fLnz+/+ALReb/sDINYIPYjZX/r2S97SfdDYh928efNcT9e4cePcL3qrdwpC8Fm9erV69+6tTz/9VIULF1YQRf41a/VMFoJq1Kiht956S9dcc42C8AeP9fQ89thj7rb19NjvgmeffTaQoeeFF15w/09Yz19QvPXWW3r99dc1ZswYN6xvvw/tj2B7D2L9/wChB7nulltu0Ycffuhmsllhb9DYX7THHHOMu37iiSe6v3SffPJJV9Sb6Kx+a+PGjWrWrFnqOfsrz/5fePrpp7V37173l1+QlC5dWscee6yWLl2qIKhcufJBAf+4447TO++8o6BZuXKlK2gfP368guSuu+5yvT0XX3yxu22z9+y9sBm+hB4kDJut1KtXLzecM3Xq1MAVLx7uL1/7sA+CDh06uOG9SDZrw7q577nnnsAFnnBR97Jly3T55ZcrCGxIO/1SFVbbYb1dQWPF3FbXFC7oDYpdu3YpKSltCbH97Nvvwlgj9MTgF1zkX3QrVqxwXXtWzHv00Ucr0Ye0rDvz/fffd7UL69evd+dtmqKt1RAE/fr1c13Z9m+9fft2935YAJw0aZKCwP7d09dw2XIFtl5LUGq77rzzTjeLzz7k165d63aZtl/43bt3VxDcfvvtrpDVhrcuuugiN2Nn1KhR7ggS+4C30GM9G0FassDY//9Ww2O/B214y5bsGDp0qCvmjjnbZR25Z8qUKbb60kFHjx49Qokuo+/bjtGjR4eC4uqrrw7VqFEjlJycHCpfvnyoQ4cOoU8++SQUZG3btg317t07FBTdunULVa5c2f0/ULVqVXd76dKloSD53//+F2rYsGGoUKFCofr164dGjRoVCppJkya5339LliwJBc22bdvcz/zRRx8dKly4cKh27dqh++67L7R3796YtyWf/Sf2UQsAACC2WKcHAAAEAqEHAAAEAqEHAAAEAqEHAAAEAqEHAAAEAqEHAAAEAqEHAAAEAqEHAAAEAqEHAAAEAqEHQMK68sorlS9fPg0ePDjN+ffee8+dBxAshB4ACa1w4cJ6/PHHtXnzZr+bAsBnhB4ACa1jx46qVKmSBg0a5HdTAPiM0AMgoeXPn1+PPfaY/vOf/+jXX3/1uzkAfEToAZDwzjvvPDVp0kQDBw70uykAfEToARAIVtfz8ssva9GiRX43BYBPCD0AAuG0005Tp06d1K9fP7+bAsAnBfx6YQCINZu6bsNc9erV87spAHxATw+AwGjUqJEuvfRSPfXUU343BYAPCD0AAuWhhx5SSkqK380A4IN8oVAo5McLAwAAxBI9PQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAIBAIPQAAQEHw/4ye7tbt+LmCAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "N = 8\n",
+    "alpha = pf.Parameter(\"alpha\")\n",
+    "R = pf.Parameter(\"R\")\n",
+    "alpha_value = 1\n",
+    "R_value = 1\n",
+    "\n",
+    "ctx_plt = make_ctx_appm(ctx_name=\"ctx_plt\", N=N, stepsize=alpha)\n",
+    "pb_plt = pf.PEPBuilder(ctx_plt)\n",
+    "pb_plt.add_initial_constraint(\n",
+    "    ((ctx_plt[\"x_0\"] - ctx_plt[\"x_star\"]) ** 2).le(R, name=\"initial_condition\")\n",
+    ")\n",
+    "\n",
+    "opt_values = []\n",
+    "for k in range(1, N + 1):\n",
+    "    x_k = ctx_plt[f\"x_{k}\"]\n",
+    "    pb_plt.set_performance_metric(A(x_k) ** 2)\n",
+    "    result = pb_plt.solve(resolve_parameters={\"alpha\": alpha_value, \"R\": R_value})\n",
+    "    opt_values.append(result.opt_value)\n",
+    "\n",
+    "iters = np.arange(1, N + 1)\n",
+    "cont_iters = np.arange(1, N, 0.01)\n",
+    "plt.plot(\n",
+    "    cont_iters,\n",
+    "    1 / (alpha_value**2 * cont_iters**2),\n",
+    "    \"r-\",\n",
+    "    label=\"Analytical bound $\\\\frac{1}{\\\\alpha^2 k^2}$\",\n",
+    ")\n",
+    "plt.scatter(iters, opt_values, color=\"blue\", marker=\"o\", label=\"Numerical values\")\n",
+    "plt.xlabel(\"N\")\n",
+    "plt.ylabel(r\"Worst-case $\\|\\tilde{A} x_N\\|^2$\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32135ceb",
+   "metadata": {},
+   "source": [
+    "## Verification of convergence of APPM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "79bf9989",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.06250301959936219\n"
+     ]
+    }
+   ],
+   "source": [
+    "N = sp.S(4)\n",
+    "alpha_value = sp.S(1)\n",
+    "R_value = sp.S(1)\n",
+    "\n",
+    "ctx_prf = make_ctx_appm(ctx_name=\"ctx_prf\", N=N, stepsize=alpha)\n",
+    "pb_prf = pf.PEPBuilder(ctx_prf)\n",
+    "pb_prf.add_initial_constraint(\n",
+    "    ((ctx_prf[\"x_0\"] - ctx_prf[\"x_star\"]) ** 2).le(R, name=\"initial_condition\")\n",
+    ")\n",
+    "pb_prf.set_performance_metric(A(ctx_prf[f\"x_{N}\"]) ** 2)\n",
+    "\n",
+    "result = pb_prf.solve(resolve_parameters={\"alpha\": alpha_value, \"R\": R_value})\n",
+    "print(result.opt_value)\n",
+    "\n",
+    "# Dual variables associated with the interpolations conditions of f with no relaxation\n",
+    "lamb_dense = result.get_scalar_constraint_dual_value_in_numpy(A)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cea37a36",
+   "metadata": {},
+   "source": [
+    "### It turns out that no relaxation of dual variables is needed (the solver output is already sparse), so we store the results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d496c94b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dual variable associated with the initial condition\n",
+    "tau_sol = result.dual_var_manager.dual_value(\"initial_condition\")\n",
+    "\n",
+    "# Dual variable associated with the interpolations conditions of A\n",
+    "lamb_sol = result.get_scalar_constraint_dual_value_in_numpy(A)\n",
+    "\n",
+    "# Dual variable associated with the Gram matrix G\n",
+    "S_sol = result.get_gram_dual_matrix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "28b53746",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccc}\n",
+       "         & x_2 & x_3 & x_4 & x_\\star \\\\\n",
+       "        \\hline\n",
+       "        x_1 & 0.25 & 0.0 & 0.0 & 0.0 \\\\x_2 & 0.0 & 0.75 & 0.0 & 0.0 \\\\x_3 & 0.0 & 0.0 & 1.5 & 0.0 \\\\x_4 & 0.0 & 0.0 & 0.0 & 0.5 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lamb_sol.pprint()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3297f5b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccccc}\n",
+       "         & y_0 & x_\\star & A(x_1) & A(x_2) & A(x_3) & A(x_4) \\\\\n",
+       "        \\hline\n",
+       "        y_0 & 0.062 & -0.062 & -0.0 & 0.0 & 0.0 & -0.25 \\\\x_\\star & -0.062 & 0.062 & 0.0 & -0.0 & -0.0 & 0.25 \\\\A(x_1) & -0.0 & 0.0 & 0.0 & -0.0 & -0.0 & 0.0 \\\\A(x_2) & 0.0 & -0.0 & -0.0 & 0.0 & 0.0 & -0.0 \\\\A(x_3) & 0.0 & -0.0 & -0.0 & 0.0 & 0.0 & -0.0 \\\\A(x_4) & -0.25 & 0.25 & 0.0 & -0.0 & -0.0 & 1.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "S_sol.pprint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5e97f34",
+   "metadata": {},
+   "source": [
+    "### The Gram dual matrix $S$ has rank 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "09f074e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.int64(1)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.linalg.matrix_rank(S_sol.matrix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e00cf3f",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccd3a2c6",
+   "metadata": {},
+   "source": [
+    "## Step 1. Propose a candidate Lyapunov function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60f505ad",
+   "metadata": {},
+   "source": [
+    "### Choose $\\mathcal{I}_k = \\{(j+1,j): j=1,\\dots,k\\}, \\mathcal{I}_0 = \\emptyset, \\mathcal{J}_k = \\emptyset$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "08b40c13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyap = [pf.Scalar.zero()]\n",
+    "partial_sum = pf.Scalar.zero()\n",
+    "for j in np.arange(1, N):\n",
+    "    partial_sum += lamb_sol(f\"x_{j}\", f\"x_{j + 1}\") * A.interp_ineq(\n",
+    "        f\"x_{j}\", f\"x_{j + 1}\"\n",
+    "    )\n",
+    "    lyap.append(partial_sum)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45c0789c",
+   "metadata": {},
+   "source": [
+    "## Step 2. Check for admissibility"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34bab1c8",
+   "metadata": {},
+   "source": [
+    "### Sufficiency is immediate.\n",
+    "### To check rank consistency and conciseness, verify that the ranks of $\\mathbf{V}_k$ are constantly 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d58cc17c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank of lyap[0]: 0\n",
+      "Rank of lyap[1]: 2\n",
+      "Rank of lyap[2]: 2\n",
+      "Rank of lyap[3]: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "pm = pf.ExpressionManager(ctx_prf, resolve_parameters={\"alpha\": sp.S(1)})\n",
+    "\n",
+    "for k in range(len(lyap)):\n",
+    "    lyap_numeric_k = pm.eval_scalar(lyap[k]).inner_prod_coords.astype(float)\n",
+    "    print(f\"Rank of lyap[{k}]: {np.linalg.matrix_rank(lyap_numeric_k, tol=1e-6)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e9e1900",
+   "metadata": {},
+   "source": [
+    "## Step 3. Build a set of special candidate vectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "731f6130",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyap_basis_candidate = ctx_prf.basis_vectors()  # add x_0, x_star and Ax_1, ... , Ax_N\n",
+    "x = [ctx_prf[f\"x_{i}\"] for i in range(1, N + 1)]\n",
+    "# Add x_1, ... , x_N\n",
+    "lyap_basis_candidate += x\n",
+    "\n",
+    "# Add all pairwise differences between the previous special vectors\n",
+    "for i, j in combinations(range(len(lyap_basis_candidate)), 2):\n",
+    "    diff = lyap_basis_candidate[i] - lyap_basis_candidate[j]\n",
+    "    diff.add_tag(f\"{lyap_basis_candidate[i].tag}-{lyap_basis_candidate[j].tag}\")\n",
+    "    lyap_basis_candidate.append(diff)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8f0be256",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[y_0, x_star, A(x_1), A(x_2), A(x_3), A(x_4), x_1, x_2, x_3, x_4, y_0-x_star, y_0-A(x_1), y_0-A(x_2), y_0-A(x_3), y_0-A(x_4), y_0-x_1, y_0-x_2, y_0-x_3, y_0-x_4, x_star-A(x_1), x_star-A(x_2), x_star-A(x_3), x_star-A(x_4), x_star-x_1, x_star-x_2, x_star-x_3, x_star-x_4, A(x_1)-A(x_2), A(x_1)-A(x_3), A(x_1)-A(x_4), A(x_1)-x_1, A(x_1)-x_2, A(x_1)-x_3, A(x_1)-x_4, A(x_2)-A(x_3), A(x_2)-A(x_4), A(x_2)-x_1, A(x_2)-x_2, A(x_2)-x_3, A(x_2)-x_4, A(x_3)-A(x_4), A(x_3)-x_1, A(x_3)-x_2, A(x_3)-x_3, A(x_3)-x_4, A(x_4)-x_1, A(x_4)-x_2, A(x_4)-x_3, A(x_4)-x_4, x_1-x_2, x_1-x_3, x_1-x_4, x_2-x_3, x_2-x_4, x_3-x_4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(lyap_basis_candidate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf079bdd",
+   "metadata": {},
+   "source": [
+    "## Step 4. Find a basis of $\\mathbf{V}_k$ within lyap_basis_candidate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a6ce575f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pepflow.lyapunov_utils import (\n",
+    "    vectors_in_column_space,\n",
+    "    find_symmetric_coefficient_matrix,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8737568",
+   "metadata": {},
+   "source": [
+    "### We find that $Ax_{k+1}$ and $x_0 - x_{k+1}$ is the correct choice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ef0d184b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_0: []\n",
+      "V_1: [A(x_1), A(x_2), y_0-x_1, y_0-x_2, A(x_1)-A(x_2), x_1-x_2]\n",
+      "V_2: [A(x_3), y_0-x_3]\n",
+      "V_3: [A(x_4), y_0-x_4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for k in range(len(lyap)):\n",
+    "    print(\n",
+    "        f\"V_{k}:\",\n",
+    "        vectors_in_column_space(\n",
+    "            lyap[k],\n",
+    "            lyap_basis_candidate,\n",
+    "            ctx_prf,\n",
+    "            resolve_parameters=pm.resolve_parameters,\n",
+    "            rtol=1e-4,\n",
+    "            atol=1e-4,\n",
+    "        ),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f28023d",
+   "metadata": {},
+   "source": [
+    "### We can numerically inspect the coefficient matrix. In particular, coefficient of the $\\|y_0 - x_{k+1}\\|^2$ term seems to be $0$\n",
+    "### Define $V_k = a_k \\|\\tilde{A}x_{k+1}\\|^2 + b_k \\langle \\tilde{A}x_{k+1} , y_0 - x_{k+1} \\rangle$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "36c744e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_1:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & A(x_2) & y_0-x_2 \\\\\n",
+       "        \\hline\n",
+       "        A(x_2) & 0.5 & -0.125 \\\\y_0-x_2 & -0.125 & 0.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_2:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & A(x_3) & y_0-x_3 \\\\\n",
+       "        \\hline\n",
+       "        A(x_3) & 1.125 & -0.187 \\\\y_0-x_3 & -0.187 & 0.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_3:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & A(x_4) & y_0-x_4 \\\\\n",
+       "        \\hline\n",
+       "        A(x_4) & 2.0 & -0.25 \\\\y_0-x_4 & -0.25 & 0.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for k in np.arange(1, len(lyap)):\n",
+    "    aligned_special_vectors_k = [ctx_prf[f\"A(x_{k + 1})\"], ctx_prf[f\"y_0-x_{k + 1}\"]]\n",
+    "    C_k = find_symmetric_coefficient_matrix(\n",
+    "        lyap[k],\n",
+    "        aligned_special_vectors_k,\n",
+    "        pep_context=ctx_prf,\n",
+    "        resolve_parameters=pm.resolve_parameters,\n",
+    "    )\n",
+    "    labels_k = [str(v) for v in aligned_special_vectors_k]\n",
+    "    print(f\"V_{k}:\")\n",
+    "    pf.pprint_labeled_matrix(C_k, labels_k, labels_k)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0864e17",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08de76fa",
+   "metadata": {},
+   "source": [
+    "## Step 5. Analytic proof"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d864dad",
+   "metadata": {},
+   "source": [
+    "### We first need closed-form expressions of $\\lambda$ and $S$.\n",
+    "### This can be done from numerical inspection with different $N$. Here we show how to check your guess by code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "90d48630",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tag_to_index(tag, N=N):\n",
+    "    \"\"\"Return the iterate index encoded in a point tag.\n",
+    "\n",
+    "    The zero point y_star is indexed as N + 1.\n",
+    "    \"\"\"\n",
+    "    idx = tag.split(\"_\", 1)[1]\n",
+    "    if idx.isdigit():\n",
+    "        return int(idx)\n",
+    "    if idx == \"star\":\n",
+    "        return N + 1\n",
+    "    raise ValueError(f\"Unknown point tag: {tag}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c37fde",
+   "metadata": {},
+   "source": [
+    "### Candidate formula for $\\lambda$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d10ca7b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccc}\n",
+       "         & x_2 & x_3 & x_4 & x_\\star \\\\\n",
+       "        \\hline\n",
+       "        x_1 & 0.25 & 0.0 & 0.0 & 0.0 \\\\x_2 & 0.0 & 0.75 & 0.0 & 0.0 \\\\x_3 & 0.0 & 0.0 & 1.5 & 0.0 \\\\x_4 & 0.0 & 0.0 & 0.0 & 0.5 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def lamb(tag_i, tag_j, N=N):\n",
+    "    i = tag_to_index(tag_i)\n",
+    "    j = tag_to_index(tag_j)\n",
+    "    if j - 1 == i:\n",
+    "        if j == N + 1:\n",
+    "            return sp.S(2) / N  ## Between N and optimal\n",
+    "        else:\n",
+    "            return sp.S(2) * (sp.S(j) - sp.S(1)) * sp.S(j) / N**2  ## Consecutive\n",
+    "    return 0\n",
+    "\n",
+    "\n",
+    "lamb_cand = pf.pprint_labeled_matrix(\n",
+    "    lamb, lamb_sol.row_names, lamb_sol.col_names, return_matrix=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc429391",
+   "metadata": {},
+   "source": [
+    "### Verify that the prposed formula matches with numerical values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "09701ba6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Did we guess the right closed form of lambda? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\n",
+    "    \"Did we guess the right closed form of lambda?\",\n",
+    "    np.allclose(lamb_cand, lamb_sol.matrix, atol=1e-3),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b9328a1",
+   "metadata": {},
+   "source": [
+    "### Candidate formula for $S$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "2a6eff23",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[y_0, x_star, A(x_1), A(x_2), A(x_3), A(x_4)]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ctx_prf.basis_vectors()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "5fb536c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccccc}\n",
+       "         & y_0 & x_\\star & A(x_1) & A(x_2) & A(x_3) & A(x_4) \\\\\n",
+       "        \\hline\n",
+       "        y_0 & 0.062 & -0.062 & 0.0 & 0.0 & 0.0 & -0.25 \\\\x_\\star & -0.062 & 0.062 & 0.0 & 0.0 & 0.0 & 0.25 \\\\A(x_1) & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 \\\\A(x_2) & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 \\\\A(x_3) & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 \\\\A(x_4) & -0.25 & 0.25 & 0.0 & 0.0 & 0.0 & 1.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x_0 = ctx_prf[\"x_0\"]\n",
+    "x_N = ctx_prf[f\"x_{N}\"]\n",
+    "x_star = ctx_prf[\"x_star\"]\n",
+    "\n",
+    "S_guess = (A(x_N) - 1 / (alpha * N) * (x_0 - x_star)) ** 2\n",
+    "\n",
+    "S_guess_eval = pm.eval_scalar(S_guess).matrix\n",
+    "pf.pprint_labeled_matrix(S_guess_eval, S_sol.row_names, S_sol.col_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "111b24e3",
+   "metadata": {},
+   "source": [
+    "### Again, verify that the prposed formula matches with numerical values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "2e1b267f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Did we guess the right closed form of S? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\n",
+    "    \"Did we guess the right closed form of S?\",\n",
+    "    np.allclose(S_guess_eval, S_sol.matrix, atol=1e-3),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2499dddc",
+   "metadata": {},
+   "source": [
+    "### Finally, we symbolically determine the Lyapunov function coefficients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "65b7d2e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# New PEP context for symbolic solve and verification\n",
+    "ctx_appm_lyap = pf.PEPContext(\"appm_lyap_finder\").set_as_current()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "613d82b5",
+   "metadata": {},
+   "source": [
+    "### APPM is equivalent to OHM $y_{k+1} = \\frac{1}{k+2} y_0 + \\frac{k+1}{k+2} Ty_k$ with $T=2J_A - I$\n",
+    "### Express $V_k - V_{k+1} - \\frac{2(k+1)(k+2)}{N^2} \\langle \\tilde{A}x_{k+1} - \\tilde{A}x_{k+2} , x_{k+1} - x_{k+2} \\rangle = 0$ as a system of equations and solve for $a_k, b_k, a_{k+1}, b_{k+1}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "9221b21f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_0 = pf.Vector(is_basis=True, tags=[\"y_0\"])\n",
+    "y_k = pf.Vector(is_basis=True, tags=[\"y_k\"])\n",
+    "Ax_k1 = pf.Vector(is_basis=True, tags=[\"Ax_{k+1}\"])\n",
+    "Ax_k2 = pf.Vector(is_basis=True, tags=[\"Ax_{k+2}\"])\n",
+    "k = pf.Parameter(\"k\")\n",
+    "alpha = 1\n",
+    "\n",
+    "y_k1 = 1 / (k + 2) * y_0 + (k + 1) / (k + 2) * (y_k - 2 * Ax_k1)\n",
+    "\n",
+    "a_k = pf.Parameter(\"a_k\")\n",
+    "a_k1 = pf.Parameter(\"a_{k+1}\")\n",
+    "b_k = pf.Parameter(\"b_k\")\n",
+    "b_k1 = pf.Parameter(\"b_{k+1}\")\n",
+    "N = pf.Parameter(\"N\")\n",
+    "\n",
+    "x_k1 = y_k - Ax_k1\n",
+    "x_k2 = y_k1 - Ax_k2\n",
+    "\n",
+    "V_k = a_k * Ax_k1 * Ax_k1 + b_k * (y_0 - x_k1) * Ax_k1\n",
+    "V_k1 = a_k1 * Ax_k2 * Ax_k2 + b_k1 * (y_0 - x_k2) * Ax_k2\n",
+    "\n",
+    "diff = V_k - V_k1 - 2 * (k + 1) * (k + 2) / N**2 * (Ax_k1 - Ax_k2) * (x_k1 - x_k2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "1ec61868",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['y_0', 'y_k', 'Ax_{k+1}', 'Ax_{k+2}']"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basis = ctx_appm_lyap.basis_vectors()\n",
+    "row_index = [str(v) for v in basis]\n",
+    "row_index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "08303e8c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccc}\n",
+       "         & y_0 & y_k & Ax_{k+1} & Ax_{k+2} \\\\\n",
+       "        \\hline\n",
+       "        y_0 & 0 & 0 & 0.5*b_k + 0.5*(2*k + 2)/N^2 & -0.5*b_{k+1}*(1.0 - 1.0/(k + 2)) - 0.5*(2*k + 2)/N^2 \\\\y_k & 0 & 0 & -0.5*b_k - 0.5*(k + 2)*(2*k + 2)*(-1.0*(k + 1)/(k + 2) + 1.0)/N^2 & 0.5*b_{k+1}*(k + 1)/(k + 2) + 0.5*(k + 2)*(2*k + 2)*(-1.0*(k + 1)/(k + 2) + 1.0)/N^2 \\\\Ax_{k+1} & 0.5*b_k + 0.5*(2*k + 2)/N^2 & -0.5*b_k - 0.5*(k + 2)*(2*k + 2)*(-1.0*(k + 1)/(k + 2) + 1.0)/N^2 & 1.0*a_k + 1.0*b_k - 1.0*(k + 2)*(2*k + 2)*(2.0*(k + 1)/(k + 2) - 1.0)/N^2 & -1.0*b_{k+1}*(k + 1)/(k + 2) + 0.5*(k + 2)*(2*k + 2)*(2.0*(k + 1)/(k + 2) - 1.0)/N^2 - 0.5*(k + 2)*(2*k + 2)/N^2 \\\\Ax_{k+2} & -0.5*b_{k+1}*(1.0 - 1.0/(k + 2)) - 0.5*(2*k + 2)/N^2 & 0.5*b_{k+1}*(k + 1)/(k + 2) + 0.5*(k + 2)*(2*k + 2)*(-1.0*(k + 1)/(k + 2) + 1.0)/N^2 & -1.0*b_{k+1}*(k + 1)/(k + 2) + 0.5*(k + 2)*(2*k + 2)*(2.0*(k + 1)/(k + 2) - 1.0)/N^2 - 0.5*(k + 2)*(2*k + 2)/N^2 & -1.0*a_{k+1} - 1.0*b_{k+1} + 1.0*(k + 2)*(2*k + 2)/N^2 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pm_lyap = pf.ExpressionManager(\n",
+    "    ctx_appm_lyap,\n",
+    "    resolve_parameters={\n",
+    "        \"a_k\": sp.Symbol(\"a_k\"),\n",
+    "        \"a_{k+1}\": sp.Symbol(\"a_{k+1}\"),\n",
+    "        \"b_k\": sp.Symbol(\"b_k\"),\n",
+    "        \"b_{k+1}\": sp.Symbol(\"b_{k+1}\"),\n",
+    "        \"N\": sp.Symbol(\"N\"),\n",
+    "        \"k\": sp.Symbol(\"k\"),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "diff_matrix = pm_lyap.eval_scalar(diff).inner_prod_coords\n",
+    "pf.pprint_labeled_matrix(diff_matrix, row_index, row_index, precision=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "6c8a88f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solutions:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left\\{ a_{k} : \\frac{2 \\left(k + 1\\right)^{2}}{N^{2}}, \\  a_{k+1} : \\frac{2 \\left(k + 2\\right)^{2}}{N^{2}}, \\  b_{k} : - \\frac{2 \\left(k + 1\\right)}{N^{2}}, \\  b_{k+1} : - \\frac{2 \\left(k + 2\\right)}{N^{2}}\\right\\}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import sympy as sp\n",
+    "\n",
+    "diff_matrix_sympify = sp.Matrix(diff_matrix)\n",
+    "\n",
+    "a_k, a_k1, b_k, b_k1, N, k = sp.symbols(\"a_k a_{k+1} b_k b_{k+1} N k\")\n",
+    "\n",
+    "unknowns = (a_k, a_k1, b_k, b_k1)\n",
+    "\n",
+    "eqs = list(diff_matrix_sympify)\n",
+    "eqs = [e for e in eqs]\n",
+    "\n",
+    "sol = sp.linsolve(eqs, unknowns)\n",
+    "sol_simplify = sp.factor(sp.factor(sp.nsimplify(sol)))\n",
+    "\n",
+    "print(\"Solutions:\")\n",
+    "sol_dict = dict(zip(unknowns, next(iter(sol_simplify))))\n",
+    "display(Math(sp.latex(sol_dict)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cd5c1ff",
+   "metadata": {},
+   "source": [
+    "### Plug these values back into the equation $V_k - V_{k+1} - \\frac{2(k+1)(k+2)}{N^2} \\langle \\tilde{A}x_{k+1} - \\tilde{A}x_{k+2} , x_{k+1} - x_{k+2} \\rangle = 0$.\n",
+    "### This verifies that everything cancels out and the equality is established, *symbolically*!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "d667ca19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Verification:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if sol:\n",
+    "    print(\"\\nVerification:\")\n",
+    "    display(sp.simplify(diff_matrix_sympify.subs(sol_dict)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pepflow (3.11.13.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples_lyapunov/appm/appm_example_lyap.ipynb
+++ b/examples_lyapunov/appm/appm_example_lyap.ipynb
@@ -37,7 +37,9 @@
     "import sympy as sp\n",
     "import matplotlib.pyplot as plt\n",
     "from itertools import combinations\n",
-    "from IPython.display import display, Math"
+    "from IPython.display import display, Math\n",
+    "\n",
+    "import pepflow.lyapunov_utils as lu"
    ]
   },
   {
@@ -107,7 +109,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x237fec5f890>"
+       "<matplotlib.legend.Legend at 0x1687ddb44d0>"
       ]
      },
      "execution_count": 4,
@@ -448,19 +450,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "a6ce575f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pepflow.lyapunov_utils import (\n",
-    "    vectors_in_column_space,\n",
-    "    find_symmetric_coefficient_matrix,\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "b8737568",
    "metadata": {},
@@ -470,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "ef0d184b",
    "metadata": {},
    "outputs": [
@@ -478,14 +467,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "V_0:"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " []\n",
+      "V_0: []\n",
       "V_1: [A(x_1), A(x_2), y_0-x_1, y_0-x_2, A(x_1)-A(x_2), x_1-x_2]\n",
       "V_2: [A(x_3), y_0-x_3]\n",
       "V_3: [A(x_4), y_0-x_4]\n"
@@ -496,7 +478,7 @@
     "for k in range(len(lyap)):\n",
     "    print(\n",
     "        f\"V_{k}:\",\n",
-    "        vectors_in_column_space(\n",
+    "        lu.vectors_in_column_space(\n",
     "            lyap[k],\n",
     "            lyap_basis_candidate,\n",
     "            ctx_prf,\n",
@@ -518,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "36c744e0",
    "metadata": {},
    "outputs": [
@@ -601,7 +583,7 @@
    "source": [
     "for k in np.arange(1, len(lyap)):\n",
     "    aligned_special_vectors_k = [ctx_prf[f\"A(x_{k + 1})\"], ctx_prf[f\"y_0-x_{k + 1}\"]]\n",
-    "    C_k = find_symmetric_coefficient_matrix(\n",
+    "    C_k = lu.find_symmetric_coefficient_matrix(\n",
     "        lyap[k],\n",
     "        aligned_special_vectors_k,\n",
     "        pep_context=ctx_prf,\n",
@@ -639,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "90d48630",
    "metadata": {},
    "outputs": [],
@@ -667,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "d10ca7b3",
    "metadata": {},
    "outputs": [
@@ -717,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "09701ba6",
    "metadata": {},
    "outputs": [
@@ -746,7 +728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "2a6eff23",
    "metadata": {},
    "outputs": [
@@ -756,7 +738,7 @@
        "[y_0, x_star, A(x_1), A(x_2), A(x_3), A(x_4)]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -767,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "5fb536c1",
    "metadata": {},
    "outputs": [
@@ -811,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "2e1b267f",
    "metadata": {},
    "outputs": [
@@ -840,7 +822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "65b7d2e0",
    "metadata": {},
    "outputs": [],
@@ -860,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "9221b21f",
    "metadata": {},
    "outputs": [],
@@ -891,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "1ec61868",
    "metadata": {},
    "outputs": [
@@ -901,7 +883,7 @@
        "['y_0', 'y_k', 'Ax_{k+1}', 'Ax_{k+2}']"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -914,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "id": "08303e8c",
    "metadata": {},
    "outputs": [
@@ -956,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "id": "6c8a88f5",
    "metadata": {},
    "outputs": [
@@ -1011,7 +993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "id": "d667ca19",
    "metadata": {},
    "outputs": [

--- a/examples_lyapunov/gd/gd_example_lyap.ipynb
+++ b/examples_lyapunov/gd/gd_example_lyap.ipynb
@@ -114,11 +114,11 @@
     }
    ],
    "source": [
-    "N = sp.S(5)\n",
+    "N = 5\n",
     "N_int = int(N)\n",
     "R = pf.Parameter(\"R\")\n",
-    "L_value = sp.S(1)\n",
-    "R_value = sp.S(1)\n",
+    "L_value = 1\n",
+    "R_value = 1\n",
     "\n",
     "ctx_prf = make_ctx_gd(ctx_name=\"ctx_prf\", N=N, stepsize=1 / L)\n",
     "pb_prf = pf.PEPBuilder(ctx_prf)\n",

--- a/examples_lyapunov/gd/gd_example_lyap.ipynb
+++ b/examples_lyapunov/gd/gd_example_lyap.ipynb
@@ -1,0 +1,1757 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "04d92eb2",
+   "metadata": {},
+   "source": [
+    "# Gradient Descent (GD) \n",
+    "\n",
+    "This notebook applies the systematic Lyapunov-function discovery procedure to gradient descent with step size $1/L$:\n",
+    "$x_{k+1}=x_k-\\frac{1}{L}\\nabla f(x_k)$, for convex and $L$-smooth minimization. Its tight rate was first proved in \n",
+    "\"Performance of first-order methods for smooth convex minimization: A novel approach\" by Drori and Teboulle (2014), \n",
+    "and was later presented in a more elementary form in \"An elementary approach to tight worst case complexity analysis\n",
+    "of gradient based methods\" by Teboulle and Vaisbourd (2023).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "089b4f23",
+   "metadata": {},
+   "source": [
+    "## Import the required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c5eca513",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pepflow as pf\n",
+    "import numpy as np\n",
+    "import sympy as sp\n",
+    "import itertools\n",
+    "from IPython.display import display, Math\n",
+    "\n",
+    "from pepflow.lyapunov_utils import (\n",
+    "    vectors_in_column_space,\n",
+    "    find_basis_with_sparsest_coefficients,\n",
+    "    ldl_decompose_with_reversed_basis,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79e0766b",
+   "metadata": {},
+   "source": [
+    "## Define the function class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "59558bf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L = pf.Parameter(\"L\")\n",
+    "f = pf.SmoothConvexFunction(is_basis=True, tags=[\"f\"], L=L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3d343e2",
+   "metadata": {},
+   "source": [
+    "## Write a function that generates a PEPContext object associated with GD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7a44de2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_ctx_gd(\n",
+    "    ctx_name: str, N: int | sp.Integer, stepsize: pf.Parameter\n",
+    ") -> pf.PEPContext:\n",
+    "    ctx_gd = pf.PEPContext(ctx_name).set_as_current()\n",
+    "    x = pf.Vector(is_basis=True, tags=[\"x_0\"])\n",
+    "    f.set_stationary_point(\"x_star\")\n",
+    "\n",
+    "    for i in range(int(N)):\n",
+    "        x = x - stepsize * f.grad(x)\n",
+    "        x.add_tag(f\"x_{i + 1}\")\n",
+    "\n",
+    "    return ctx_gd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174ecbec",
+   "metadata": {},
+   "source": [
+    "## Numerical PEP solve \n",
+    "### First, find tight and sparsified proof certificates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "38251de1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dense optimum: 0.04545413917119227\n"
+     ]
+    }
+   ],
+   "source": [
+    "N = sp.S(5)\n",
+    "N_int = int(N)\n",
+    "R = pf.Parameter(\"R\")\n",
+    "L_value = sp.S(1)\n",
+    "R_value = sp.S(1)\n",
+    "\n",
+    "ctx_prf = make_ctx_gd(ctx_name=\"ctx_prf\", N=N, stepsize=1 / L)\n",
+    "pb_prf = pf.PEPBuilder(ctx_prf)\n",
+    "pb_prf.add_initial_constraint(\n",
+    "    ((ctx_prf[\"x_0\"] - ctx_prf[\"x_star\"]) ** 2).le(R, name=\"initial_condition\")\n",
+    ")\n",
+    "pb_prf.set_performance_metric(f(ctx_prf[f\"x_{N}\"]) - f(ctx_prf[\"x_star\"]))\n",
+    "\n",
+    "result_dense = pb_prf.solve(resolve_parameters={\"L\": L_value, \"R\": R_value})\n",
+    "lamb_dense = result_dense.get_scalar_constraint_dual_value_in_numpy(f)\n",
+    "\n",
+    "print(\"dense optimum:\", result_dense.opt_value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a916b9d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sparse optimum: 0.04545448086517327\n",
+      "tau: 0.04545454544805585\n"
+     ]
+    }
+   ],
+   "source": [
+    "def tag_to_index(tag: str, N: int | sp.Basic = N) -> int:\n",
+    "    if tag == \"x_star\":\n",
+    "        return int(N) + 1\n",
+    "    return int(tag.split(\"_\", 1)[1])\n",
+    "\n",
+    "\n",
+    "def gd_relaxed_constraints_from_observed_pattern(lamb_matrix, N: int | sp.Integer):\n",
+    "    relaxed = []\n",
+    "    N = int(N)\n",
+    "    for tag_i in lamb_matrix.row_names:\n",
+    "        i = tag_to_index(tag_i, N)\n",
+    "        if i == N + 1:\n",
+    "            continue\n",
+    "        for tag_j in lamb_matrix.col_names:\n",
+    "            j = tag_to_index(tag_j, N)\n",
+    "            if i < N and i + 1 == j:\n",
+    "                continue\n",
+    "            relaxed.append(f\"f:{tag_i},{tag_j}\")\n",
+    "    return relaxed\n",
+    "\n",
+    "\n",
+    "pb_prf.set_relaxed_constraints(\n",
+    "    gd_relaxed_constraints_from_observed_pattern(lamb_dense, N)\n",
+    ")\n",
+    "result = pb_prf.solve(resolve_parameters={\"L\": L_value, \"R\": R_value})\n",
+    "\n",
+    "# Dual variable associated with the initial condition.\n",
+    "tau_sol = result.dual_var_manager.dual_value(\"initial_condition\")\n",
+    "# Dual variables associated with the interpolation conditions of f.\n",
+    "lamb_sol = result.get_scalar_constraint_dual_value_in_numpy(f)\n",
+    "# Dual matrix associated with the Gram matrix.\n",
+    "S_sol = result.get_gram_dual_matrix()\n",
+    "\n",
+    "print(\"sparse optimum:\", result.opt_value)\n",
+    "print(\"tau:\", tau_sol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e67c3a00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|ccccccc}\n",
+       "         & x_0 & x_1 & x_2 & x_3 & x_4 & x_5 & x_\\star \\\\\n",
+       "        \\hline\n",
+       "        x_0 & 0.0 & 0.1 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 \\\\x_1 & 0.0 & 0.0 & 0.222 & 0.0 & 0.0 & 0.0 & 0.0 \\\\x_2 & 0.0 & 0.0 & 0.0 & 0.375 & 0.0 & 0.0 & 0.0 \\\\x_3 & 0.0 & 0.0 & 0.0 & 0.0 & 0.571 & 0.0 & 0.0 \\\\x_4 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.833 & 0.0 \\\\x_5 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 \\\\x_\\star & 0.1 & 0.122 & 0.153 & 0.196 & 0.262 & 0.167 & 0.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lamb_sol.pprint()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d5046f3b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccccccc}\n",
+       "         & x_0 & x_\\star & \\nabla f(x_0) & \\nabla f(x_1) & \\nabla f(x_2) & \\nabla f(x_3) & \\nabla f(x_4) & \\nabla f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        x_0 & 0.045 & -0.045 & -0.05 & -0.061 & -0.076 & -0.098 & -0.131 & -0.083 \\\\x_\\star & -0.045 & 0.045 & 0.05 & 0.061 & 0.076 & 0.098 & 0.131 & 0.083 \\\\\\nabla f(x_0) & -0.05 & 0.05 & 0.1 & 0.061 & 0.076 & 0.098 & 0.131 & 0.083 \\\\\\nabla f(x_1) & -0.061 & 0.061 & 0.061 & 0.222 & 0.076 & 0.098 & 0.131 & 0.083 \\\\\\nabla f(x_2) & -0.076 & 0.076 & 0.076 & 0.076 & 0.375 & 0.098 & 0.131 & 0.083 \\\\\\nabla f(x_3) & -0.098 & 0.098 & 0.098 & 0.098 & 0.098 & 0.571 & 0.131 & 0.083 \\\\\\nabla f(x_4) & -0.131 & 0.131 & 0.131 & 0.131 & 0.131 & 0.131 & 0.833 & 0.083 \\\\\\nabla f(x_5) & -0.083 & 0.083 & 0.083 & 0.083 & 0.083 & 0.083 & 0.083 & 0.5 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "S_sol.pprint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18a24f24",
+   "metadata": {},
+   "source": [
+    "### Perform the reverse-basis LDL decomposition on semidefinite matrix certificate $S$\n",
+    "### The order of the PEP basis vectors is reversed to $[\\nabla f(x_N),\\ldots,\\nabla f(x_0),x_\\star,x_0]$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "75c0a5df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cccccccc}\n",
+       "         & \\nabla f(x_5) & \\nabla f(x_4) & \\nabla f(x_3) & \\nabla f(x_2) & \\nabla f(x_1) & \\nabla f(x_0) & x_0 & x_\\star \\\\\n",
+       "        \\hline\n",
+       "        \\ell_{1} & 1.0 & 0.167 & 0.167 & 0.167 & 0.167 & 0.167 & -0.167 & 0.167 \\\\\\ell_{2} & 0.0 & 1.0 & 0.143 & 0.143 & 0.143 & 0.143 & -0.143 & 0.143 \\\\\\ell_{3} & 0.0 & 0.0 & 1.0 & 0.125 & 0.125 & 0.125 & -0.125 & 0.125 \\\\\\ell_{4} & 0.0 & 0.0 & 0.0 & 1.0 & 0.111 & 0.111 & -0.111 & 0.111 \\\\\\ell_{5} & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.1 & -0.1 & 0.1 \\\\\\ell_{6} & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & -0.091 & 0.091 \\\\\\ell_{7} & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & -0.664 \\\\\\ell_{8} & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0.5 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.819 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.541 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.336 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.179 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.055 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0.5,   0.0,   0.0,   0.0,   0.0,   0.0, 0.0, 0.0],\n",
+       "[0.0, 0.819,   0.0,   0.0,   0.0,   0.0, 0.0, 0.0],\n",
+       "[0.0,   0.0, 0.541,   0.0,   0.0,   0.0, 0.0, 0.0],\n",
+       "[0.0,   0.0,   0.0, 0.336,   0.0,   0.0, 0.0, 0.0],\n",
+       "[0.0,   0.0,   0.0,   0.0, 0.179,   0.0, 0.0, 0.0],\n",
+       "[0.0,   0.0,   0.0,   0.0,   0.0, 0.055, 0.0, 0.0],\n",
+       "[0.0,   0.0,   0.0,   0.0,   0.0,   0.0, 0.0, 0.0],\n",
+       "[0.0,   0.0,   0.0,   0.0,   0.0,   0.0, 0.0, 0.0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rank(S): 6\n",
+      "diag(D): [ 5.00000002e-01  8.19445133e-01  5.40816781e-01  3.35937847e-01\n",
+      "  1.79012431e-01  5.50000144e-02  1.77538106e-16 -1.03349710e-16]\n",
+      "nonzero diagonal entries: [0 1 2 3 4 5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pm = pf.ExpressionManager(ctx_prf, resolve_parameters={\"L\": L_value, \"R\": R_value})\n",
+    "x = ctx_prf.tracked_point(f)\n",
+    "x_0 = ctx_prf[\"x_0\"]\n",
+    "x_star = ctx_prf[\"x_star\"]\n",
+    "\n",
+    "D, ell = ldl_decompose_with_reversed_basis(\n",
+    "    S_sol, ctx_prf.basis_vectors(), print_output=True\n",
+    ")\n",
+    "\n",
+    "diag_D = np.diag(D)\n",
+    "print(\n",
+    "    \"rank(S):\", np.linalg.matrix_rank(np.asarray(S_sol.matrix, dtype=float), tol=1e-7)\n",
+    ")\n",
+    "print(\"diag(D):\", diag_D)\n",
+    "print(\"nonzero diagonal entries:\", np.where(np.abs(diag_D) > 1e-7)[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec3bac33",
+   "metadata": {},
+   "source": [
+    "### Numerical values of $D = \\mathrm{diag}(\\alpha_0, \\dots, \\alpha_5, *, *)$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "80768187",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alpha_0 = 0.0550000143791\n",
+      "alpha_1 = 0.179012431223\n",
+      "alpha_2 = 0.335937847388\n",
+      "alpha_3 = 0.540816781461\n",
+      "alpha_4 = 0.819445132815\n",
+      "alpha_5 = 0.500000002236\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Store the numerical square coefficients and vectors in chronological order:\n",
+    "# sos_vectors[i] corresponds to the square term involving data through x_i.\n",
+    "sos_coeffs = [D[N_int - i, N_int - i] for i in range(N_int + 1)]\n",
+    "sos_vectors = [ell[N_int - i] for i in range(N_int + 1)]\n",
+    "\n",
+    "for i, coeff in enumerate(sos_coeffs):\n",
+    "    print(f\"alpha_{i} = {coeff:.12g}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0d487a2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 1. Propose a candidate Lyapunov function\n",
+    "\n",
+    "### For $k=0,\\dots,N$, take $\\mathcal I_k=\\{(i-1,i):i=1,\\ldots,k\\}\\cup\\{(\\star,i):i=0,\\ldots,k\\},\\,\\, \\mathcal J_k=\\{0,\\ldots,k\\}$ and let $V_{-1}=0$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3611f960",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_raw contains: ['V_-1', 'V_0', 'V_1', 'V_2', 'V_3', 'V_4', 'V_5']\n"
+     ]
+    }
+   ],
+   "source": [
+    "def named_matrix_entry(named_matrix, row_name: str, col_name: str):\n",
+    "    row = named_matrix.row_names.index(row_name)\n",
+    "    col = named_matrix.col_names.index(col_name)\n",
+    "    return named_matrix.matrix[row, col]\n",
+    "\n",
+    "\n",
+    "def lamb_numeric(tag_i: str, tag_j: str):\n",
+    "    return named_matrix_entry(lamb_sol, tag_i, tag_j)\n",
+    "\n",
+    "\n",
+    "V_raw = [pf.Scalar.zero()]\n",
+    "partial_sum = pf.Scalar.zero()\n",
+    "\n",
+    "partial_sum += lamb_numeric(\"x_star\", \"x_0\") * f.interp_ineq(\"x_star\", \"x_0\")\n",
+    "partial_sum -= sos_coeffs[0] * sos_vectors[0] ** 2\n",
+    "V_raw.append(partial_sum)\n",
+    "\n",
+    "for step in range(N_int):\n",
+    "    partial_sum += lamb_numeric(f\"x_{step}\", f\"x_{step + 1}\") * f.interp_ineq(\n",
+    "        f\"x_{step}\", f\"x_{step + 1}\"\n",
+    "    )\n",
+    "    partial_sum += lamb_numeric(\"x_star\", f\"x_{step + 1}\") * f.interp_ineq(\n",
+    "        \"x_star\", f\"x_{step + 1}\"\n",
+    "    )\n",
+    "    partial_sum -= sos_coeffs[step + 1] * sos_vectors[step + 1] ** 2\n",
+    "    V_raw.append(partial_sum)\n",
+    "\n",
+    "print(\"V_raw contains:\", [f\"V_{i - 1}\" for i in range(len(V_raw))])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7771c33",
+   "metadata": {},
+   "source": [
+    "## Step 2. Check for admissibility"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bd55c73",
+   "metadata": {},
+   "source": [
+    "### Sufficiency is immediate: $\\mathcal I_N=\\mathcal I$ and $\\mathcal J_N=\\mathcal J$. \n",
+    "### We check for consistency and conciseness:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c6919480",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_-1: rank=0, nonzero function coordinates=[]\n",
+      "V_0: rank=2, nonzero function coordinates=['f(x_star)', 'f(x_0)']\n",
+      "V_1: rank=3, nonzero function coordinates=['f(x_star)', 'f(x_1)']\n",
+      "V_2: rank=3, nonzero function coordinates=['f(x_star)', 'f(x_2)']\n",
+      "V_3: rank=3, nonzero function coordinates=['f(x_star)', 'f(x_3)']\n",
+      "V_4: rank=3, nonzero function coordinates=['f(x_star)', 'f(x_4)']\n",
+      "V_5: rank=1, nonzero function coordinates=['f(x_star)', 'f(x_5)']\n",
+      "\n",
+      "Function-value vector at last iteration:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -1.0 & 0.0 & 0.0 & 0.0 & -0.0 & -0.0 & 1.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "scalar_labels = [str(s) for s in ctx_prf.basis_scalars()]\n",
+    "\n",
+    "for idx, V in enumerate(V_raw):\n",
+    "    k_label = idx - 1\n",
+    "    V_eval = pm.eval_scalar(V)\n",
+    "    rank = np.linalg.matrix_rank(V_eval.inner_prod_coords.astype(float), tol=1e-6)\n",
+    "    func_coords = V_eval.func_coords.astype(float)\n",
+    "    support = [scalar_labels[i] for i, val in enumerate(func_coords) if abs(val) > 1e-7]\n",
+    "    print(f\"V_{k_label}: rank={rank}, nonzero function coordinates={support}\")\n",
+    "\n",
+    "print(\"\\nFunction-value vector at last iteration:\")\n",
+    "pf.pprint_labeled_vector(\n",
+    "    pm.eval_scalar(V_raw[N + 1]).func_coords.astype(float),\n",
+    "    scalar_labels,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2770be19",
+   "metadata": {},
+   "source": [
+    "## Step 3. Build a set of special candidate vectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c19be012",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[x_0, x_star, grad_f(x_0), grad_f(x_1), grad_f(x_2), grad_f(x_3), grad_f(x_4), grad_f(x_5), x_1, x_2, x_3, x_4, x_5, x_0-x_star, x_0-grad_f(x_0), x_0-grad_f(x_1), x_0-grad_f(x_2), x_0-grad_f(x_3), x_0-grad_f(x_4), x_0-grad_f(x_5), x_0-(x_1), x_0-(x_2), x_0-(x_3), x_0-(x_4), x_0-(x_5), x_star-grad_f(x_0), x_star-grad_f(x_1), x_star-grad_f(x_2), x_star-grad_f(x_3), x_star-grad_f(x_4), x_star-grad_f(x_5), x_star-(x_1), x_star-(x_2), x_star-(x_3), x_star-(x_4), x_star-(x_5), grad_f(x_0)-grad_f(x_1), grad_f(x_0)-grad_f(x_2), grad_f(x_0)-grad_f(x_3), grad_f(x_0)-grad_f(x_4), grad_f(x_0)-grad_f(x_5), grad_f(x_0)-(x_1), grad_f(x_0)-(x_2), grad_f(x_0)-(x_3), grad_f(x_0)-(x_4), grad_f(x_0)-(x_5), grad_f(x_1)-grad_f(x_2), grad_f(x_1)-grad_f(x_3), grad_f(x_1)-grad_f(x_4), grad_f(x_1)-grad_f(x_5), grad_f(x_1)-(x_1), grad_f(x_1)-(x_2), grad_f(x_1)-(x_3), grad_f(x_1)-(x_4), grad_f(x_1)-(x_5), grad_f(x_2)-grad_f(x_3), grad_f(x_2)-grad_f(x_4), grad_f(x_2)-grad_f(x_5), grad_f(x_2)-(x_1), grad_f(x_2)-(x_2), grad_f(x_2)-(x_3), grad_f(x_2)-(x_4), grad_f(x_2)-(x_5), grad_f(x_3)-grad_f(x_4), grad_f(x_3)-grad_f(x_5), grad_f(x_3)-(x_1), grad_f(x_3)-(x_2), grad_f(x_3)-(x_3), grad_f(x_3)-(x_4), grad_f(x_3)-(x_5), grad_f(x_4)-grad_f(x_5), grad_f(x_4)-(x_1), grad_f(x_4)-(x_2), grad_f(x_4)-(x_3), grad_f(x_4)-(x_4), grad_f(x_4)-(x_5), grad_f(x_5)-(x_1), grad_f(x_5)-(x_2), grad_f(x_5)-(x_3), grad_f(x_5)-(x_4), grad_f(x_5)-(x_5), x_1-(x_2), x_1-(x_3), x_1-(x_4), x_1-(x_5), x_2-(x_3), x_2-(x_4), x_2-(x_5), x_3-(x_4), x_3-(x_5), x_4-(x_5)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctx_prf.set_as_current()\n",
+    "lyap_basis_candidate = list(ctx_prf.basis_vectors())\n",
+    "lyap_basis_candidate += x[1 : N_int + 1]\n",
+    "\n",
+    "base_count = len(lyap_basis_candidate)\n",
+    "for i, j in itertools.combinations(range(base_count), 2):\n",
+    "    diff = lyap_basis_candidate[i] - lyap_basis_candidate[j]\n",
+    "    lyap_basis_candidate.append(diff)\n",
+    "\n",
+    "print(lyap_basis_candidate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e680527",
+   "metadata": {},
+   "source": [
+    "## Step 4. Find a basis of $\\mathbf V_k$ within the candidate vectors\n",
+    "\n",
+    "### We observe that all $V_k$ ($k=1,\\dots,N-1$) contains a term $-\\tau\\|x_0-x_\\star\\|^2$, where $\\tau=\\tau_N$ is the value of the worst-case performance metric."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ca2d991b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_-1: []\n",
+      "V_0: [grad_f(x_0), x_0-x_star, x_0-(x_1), x_star-(x_1)]\n",
+      "V_1: [grad_f(x_0), grad_f(x_1), x_0-x_star, x_0-(x_1), x_0-(x_2), x_star-(x_1), x_star-(x_2), grad_f(x_0)-grad_f(x_1), x_1-(x_2)]\n",
+      "V_2: [grad_f(x_2), x_0-x_star, x_0-(x_2), x_0-(x_3), x_star-(x_2), x_star-(x_3), x_2-(x_3)]\n",
+      "V_3: [grad_f(x_3), x_0-x_star, x_0-(x_3), x_0-(x_4), x_star-(x_3), x_star-(x_4), x_3-(x_4)]\n",
+      "V_4: [grad_f(x_4), x_0-x_star, x_0-(x_4), x_0-(x_5), x_star-(x_4), x_star-(x_5), x_4-(x_5)]\n",
+      "V_5: [x_0-x_star]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for idx, V in enumerate(V_raw):\n",
+    "    print(\n",
+    "        f\"V_{idx - 1}:\",\n",
+    "        vectors_in_column_space(\n",
+    "            V,\n",
+    "            lyap_basis_candidate,\n",
+    "            ctx_prf,\n",
+    "            resolve_parameters=pm.resolve_parameters,\n",
+    "            rtol=1e-5,\n",
+    "            atol=1e-5,\n",
+    "        ),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b5e2dad1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_1:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|ccc}\n",
+       "         & \\nabla f(x_1) & x_0-x_\\star & x_\\star-(x_2) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_1) & -0.111 & 0.0 & 0.0 \\\\x_0-x_\\star & 0.0 & -0.045 & 0.0 \\\\x_\\star-(x_2) & 0.0 & 0.0 & 0.043 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_2:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|ccc}\n",
+       "         & \\nabla f(x_2) & x_0-x_\\star & x_\\star-(x_3) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_2) & -0.188 & 0.0 & 0.0 \\\\x_0-x_\\star & 0.0 & -0.045 & 0.0 \\\\x_\\star-(x_3) & 0.0 & 0.0 & 0.039 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_3:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|ccc}\n",
+       "         & \\nabla f(x_3) & x_0-x_\\star & x_\\star-(x_4) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_3) & -0.286 & -0.0 & -0.0 \\\\x_0-x_\\star & -0.0 & -0.045 & 0.0 \\\\x_\\star-(x_4) & -0.0 & 0.0 & 0.031 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "V_4:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|ccc}\n",
+       "         & \\nabla f(x_4) & x_0-x_\\star & x_\\star-(x_5) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_4) & -0.417 & -0.0 & -0.0 \\\\x_0-x_\\star & -0.0 & -0.045 & 0.0 \\\\x_\\star-(x_5) & -0.0 & 0.0 & 0.014 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for idx in range(2, len(V_raw) - 1):\n",
+    "    aligned_special_vectors = vectors_in_column_space(\n",
+    "        V_raw[idx],\n",
+    "        lyap_basis_candidate,\n",
+    "        ctx_prf,\n",
+    "        resolve_parameters=pm.resolve_parameters,\n",
+    "        rtol=1e-5,\n",
+    "        atol=1e-5,\n",
+    "    )\n",
+    "    best_vectors, best_coefficients = find_basis_with_sparsest_coefficients(\n",
+    "        V_raw[idx],\n",
+    "        aligned_special_vectors,\n",
+    "        pep_context=ctx_prf,\n",
+    "        resolve_parameters=pm.resolve_parameters,\n",
+    "    )\n",
+    "    labels = [str(v) for v in best_vectors]\n",
+    "    print(f\"V_{idx - 1}:\")\n",
+    "    pf.pprint_labeled_matrix(best_coefficients, labels, labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e924359",
+   "metadata": {},
+   "source": [
+    "### Consider the translated Lyapunov function $\\widetilde V_k = V_k + \\tau\\|x_0-x_\\star\\|^2$.\n",
+    "### Then, we re-run the Steps 2-4 to verify that this is a desirable translation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "7fd1bac3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_-1: rank=1\n",
+      "tilde V_0: rank=2\n",
+      "tilde V_1: rank=2\n",
+      "tilde V_2: rank=2\n",
+      "tilde V_3: rank=2\n",
+      "tilde V_4: rank=2\n",
+      "tilde V_5: rank=0\n"
+     ]
+    }
+   ],
+   "source": [
+    "lyap = [V + tau_sol * (x_0 - x_star) ** 2 for V in V_raw]\n",
+    "\n",
+    "for idx, V in enumerate(lyap):\n",
+    "    V_eval = pm.eval_scalar(V)\n",
+    "    rank = np.linalg.matrix_rank(V_eval.inner_prod_coords.astype(float), tol=1e-6)\n",
+    "    print(f\"tilde V_{idx - 1}: rank={rank}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "68fe5b58",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_-1:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|c}\n",
+       "         & x_0-x_\\star \\\\\n",
+       "        \\hline\n",
+       "        x_0-x_\\star & 0.045 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_0:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -0.1 & 0.1 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & \\nabla f(x_0) & x_\\star-(x_1) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_0) & -0.05 & -0.0 \\\\x_\\star-(x_1) & -0.0 & 0.045 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_1:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -0.222 & 0.0 & 0.222 & 0.0 & 0.0 & 0.0 & 0.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & \\nabla f(x_1) & x_\\star-(x_2) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_1) & -0.111 & -0.0 \\\\x_\\star-(x_2) & -0.0 & 0.043 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_2:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -0.375 & 0.0 & 0.0 & 0.375 & 0.0 & 0.0 & 0.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & \\nabla f(x_2) & x_\\star-(x_3) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_2) & -0.188 & -0.0 \\\\x_\\star-(x_3) & -0.0 & 0.039 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_3:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -0.571 & 0.0 & 0.0 & 0.0 & 0.571 & 0.0 & 0.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & \\nabla f(x_3) & x_\\star-(x_4) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_3) & -0.286 & 0.0 \\\\x_\\star-(x_4) & 0.0 & 0.031 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_4:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -0.833 & 0.0 & 0.0 & 0.0 & -0.0 & 0.833 & 0.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{c|cc}\n",
+       "         & \\nabla f(x_4) & x_\\star-(x_5) \\\\\n",
+       "        \\hline\n",
+       "        \\nabla f(x_4) & -0.417 & 0.0 \\\\x_\\star-(x_5) & 0.0 & 0.014 \\\\\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tilde V_5:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\displaystyle \n",
+       "        \\begin{array}{ccccccc}\n",
+       "        f(x_\\star) & f(x_0) & f(x_1) & f(x_2) & f(x_3) & f(x_4) & f(x_5) \\\\\n",
+       "        \\hline\n",
+       "        -1.0 & 0.0 & 0.0 & 0.0 & -0.0 & -0.0 & 1.0\n",
+       "        \\end{array}\n",
+       "        $"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No candidate vector detected\n"
+     ]
+    }
+   ],
+   "source": [
+    "for idx in range(len(lyap)):\n",
+    "    aligned_special_vectors = vectors_in_column_space(\n",
+    "        lyap[idx],\n",
+    "        lyap_basis_candidate,\n",
+    "        ctx_prf,\n",
+    "        resolve_parameters=pm.resolve_parameters,\n",
+    "        rtol=1e-5,\n",
+    "        atol=1e-5,\n",
+    "    )\n",
+    "    print(f\"tilde V_{idx - 1}:\")\n",
+    "    pf.pprint_labeled_vector(\n",
+    "        pm.eval_scalar(lyap[idx]).func_coords.astype(float),\n",
+    "        scalar_labels,\n",
+    "    )\n",
+    "    if not aligned_special_vectors:\n",
+    "        print(\"No candidate vector detected\")\n",
+    "        continue\n",
+    "    else:\n",
+    "        best_vectors, best_coefficients = find_basis_with_sparsest_coefficients(\n",
+    "            lyap[idx],\n",
+    "            aligned_special_vectors,\n",
+    "            pep_context=ctx_prf,\n",
+    "            resolve_parameters=pm.resolve_parameters,\n",
+    "        )\n",
+    "        labels = [str(v) for v in best_vectors]\n",
+    "        pf.pprint_labeled_matrix(best_coefficients, labels, labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb0c7c98",
+   "metadata": {},
+   "source": [
+    "### We can hypothesize the form $\\widetilde V_k = a_k (f(x_k) - f(x_\\star)) + b_k \\|\\nabla f(x_k)\\|^2 + c_k \\|x_{k+1} - x_\\star\\|^2$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "098f5fae",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Step 5. Analytic proof\n",
+    "\n",
+    "### We use the analytic forms \n",
+    "$$\n",
+    "    \\lambda_{i-1,i}=\\frac{i}{2N+1-i}, \\qquad \\lambda_{\\star,i}=\\begin{cases}\n",
+    "\\lambda_{0,1}, & i=0,\\\\\n",
+    "\\lambda_{i,i+1}-\\lambda_{i-1,i}, & 1\\le i\\le N-1,\\\\\n",
+    "1-\\lambda_{N-1,N}, & i=N\n",
+    "\\end{cases}\n",
+    "$$\n",
+    "$$\n",
+    "    s_i=\\frac{1}{L}\\nabla f(x_i)-\\frac{1}{2N-i+1}(x_i-x_\\star),\n",
+    "    \\qquad i=0,\\ldots,N.\n",
+    "$$\n",
+    "### to determine $a_k, b_k, c_k, a_{k+1}, b_{k+1}, c_{k+1}, \\alpha_{k+1}$ from the equation\n",
+    "$$\n",
+    "    \\widetilde{V}_k - \\widetilde{V}_{k+1} = -\\lambda_{k,k+1} \\left( f(x_{k+1})-f(x_k) + \\langle \\nabla f(x_{k+1}) , x_{k} - x_{k+1} \\rangle + \\frac{1}{2 L} \\| \\nabla f(x_{k}) - \\nabla f(x_{k+1}) \\|^2 \\right)  \n",
+    "    - \\lambda_{\\star,k+1} \\left( f(x_{k+1})-f(x_{\\star}) + \\langle \\nabla f(x_{k+1}) , x_{\\star} - x_{k+1} \\rangle + \\frac{1}{2 L} \\| \\nabla f(x_{k+1}) \\|^2 \\right) + \\alpha_{k+1} \\left\\|\\frac{1}{L}\\nabla f(x_{k+1}) - \\frac{1}{2N-k} (x_{k+1} - x_\\star)\\right\\|^2 \n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b46319ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def lambda_adj_formula(i, N):\n",
+    "    if 0 <= i <= N - 1:\n",
+    "        return sp.S(i + 1) / sp.S(2 * N - i)\n",
+    "    return sp.S(0)\n",
+    "\n",
+    "\n",
+    "def lambda_star_formula(i, N):\n",
+    "    if i == 0:\n",
+    "        return lambda_adj_formula(0, N)\n",
+    "    if 1 <= i <= N - 1:\n",
+    "        return lambda_adj_formula(i, N) - lambda_adj_formula(i - 1, N)\n",
+    "    if i == N:\n",
+    "        return sp.S(1) - lambda_adj_formula(N - 1, N)\n",
+    "    return sp.S(0)\n",
+    "\n",
+    "\n",
+    "def lambda_formula(tag_i, tag_j, N):\n",
+    "    i = tag_to_index(tag_i, N)\n",
+    "    j = tag_to_index(tag_j, N)\n",
+    "    if tag_i == \"x_star\" and 0 <= j <= N:\n",
+    "        return lambda_star_formula(j, N)\n",
+    "    if 0 <= i <= N - 1 and j == i + 1:\n",
+    "        return lambda_adj_formula(i, N)\n",
+    "    return sp.S(0)\n",
+    "\n",
+    "\n",
+    "def exact_simplify(expr):\n",
+    "    return sp.factor(sp.together(sp.simplify(sp.nsimplify(expr))))\n",
+    "\n",
+    "\n",
+    "def exact_matrix(array):\n",
+    "    return sp.Matrix(array).applyfunc(exact_simplify)\n",
+    "\n",
+    "\n",
+    "def solve_symbolic_identity(diff, ctx, resolve_parameters, unknowns):\n",
+    "    pm_check = pf.ExpressionManager(ctx, resolve_parameters=resolve_parameters)\n",
+    "    matrix_part = exact_matrix(pm_check.eval_scalar(diff).inner_prod_coords)\n",
+    "    func_part = exact_matrix(pm_check.eval_scalar(diff).func_coords)\n",
+    "    equations = [entry for entry in list(matrix_part) + list(func_part) if entry != 0]\n",
+    "    solution_set = sp.linsolve(equations, unknowns)\n",
+    "    solution_tuple = next(iter(solution_set))\n",
+    "    solution = {\n",
+    "        unknown: exact_simplify(expression)\n",
+    "        for unknown, expression in zip(unknowns, solution_tuple)\n",
+    "    }\n",
+    "    return matrix_part, func_part, solution_set, solution\n",
+    "\n",
+    "\n",
+    "def residual_after_substitution(matrix_part, func_part, solution):\n",
+    "    matrix_residual = exact_matrix(matrix_part.subs(solution))\n",
+    "    func_residual = exact_matrix(func_part.subs(solution))\n",
+    "    return matrix_residual, func_residual\n",
+    "\n",
+    "\n",
+    "def display_solution(title, solution):\n",
+    "    print(title)\n",
+    "    display(\n",
+    "        Math(\n",
+    "            r\"\\begin{aligned}\"\n",
+    "            + r\"\\\\\".join(\n",
+    "                sp.latex(sp.Eq(unknown, exact_simplify(expression)))\n",
+    "                for unknown, expression in solution.items()\n",
+    "            )\n",
+    "            + r\"\\end{aligned}\"\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def display_verification(matrix_residual, func_residual):\n",
+    "    print(\"quadratic residual:\")\n",
+    "    display(matrix_residual)\n",
+    "    print(\"function-value residual:\")\n",
+    "    display(func_residual)\n",
+    "    print(\n",
+    "        \"identity verified?\",\n",
+    "        matrix_residual == sp.zeros(*matrix_residual.shape)\n",
+    "        and func_residual == sp.zeros(*func_residual.shape),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55d200f2",
+   "metadata": {},
+   "source": [
+    "### Case 1: $k=-1$\n",
+    "\n",
+    "### Here we have $\\widetilde V_{-1}=\\frac{L}{4N+2}\\|x_0-x_\\star\\|^2$ and solve $\\widetilde V_{-1}-\\widetilde V_0 = -\\lambda_{\\star,0} I_{\\star,0}+\\alpha_0\\|s_0\\|^2$ for $a_0,b_0,c_0,\\alpha_0$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3edd2b68",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution for the first transition:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\begin{aligned}a_{0} = \\frac{1}{2 N}\\\\b_{0} = - \\frac{1}{4 L N}\\\\c_{0} = \\frac{L \\left(2 N - 1\\right)}{8 N^{2}}\\\\\\alpha_{0} = \\frac{L \\left(2 N + 1\\right)}{8 N^{2}}\\end{aligned}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alpha_0 matches closed-form alpha formula? True\n",
+      "quadratic residual:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & 0 & 0\\\\0 & 0 & 0\\\\0 & 0 & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0, 0, 0],\n",
+       "[0, 0, 0],\n",
+       "[0, 0, 0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "function-value residual:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0\\\\0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0],\n",
+       "[0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "identity verified? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctx_gd_first = pf.PEPContext(\"gd_first_endpoint_solve\").set_as_current()\n",
+    "N_param = pf.Parameter(\"N\")\n",
+    "f.set_stationary_point(\"x_star\")\n",
+    "x_star_first = ctx_gd_first[\"x_star\"]\n",
+    "x0_first = pf.Vector(is_basis=True, tags=[\"x_0\"])\n",
+    "x1_first = x0_first - 1 / L * f.grad(x0_first)\n",
+    "x1_first.add_tag(\"x_1\")\n",
+    "\n",
+    "a_0 = pf.Parameter(\"a_0\")\n",
+    "b_0 = pf.Parameter(\"b_0\")\n",
+    "c_0 = pf.Parameter(\"c_0\")\n",
+    "alpha_0 = pf.Parameter(\"alpha_0\")\n",
+    "\n",
+    "V_minus_1 = L / (4 * N_param + 2) * (x0_first - x_star_first) ** 2\n",
+    "V_0_ansatz = (\n",
+    "    a_0 * (f(x0_first) - f(x_star_first))\n",
+    "    + b_0 * f.grad(x0_first) ** 2\n",
+    "    + c_0 * (x1_first - x_star_first) ** 2\n",
+    ")\n",
+    "lambda_star_0 = sp.S(1) / (2 * N_param)\n",
+    "s_0 = 1 / L * f.grad(x0_first) - 1 / (2 * N_param + 1) * (x0_first - x_star_first)\n",
+    "\n",
+    "first_identity_residual = (\n",
+    "    V_minus_1\n",
+    "    - V_0_ansatz\n",
+    "    + lambda_star_0 * f.interp_ineq(\"x_star\", \"x_0\")\n",
+    "    - alpha_0 * s_0**2\n",
+    ")\n",
+    "\n",
+    "N_sp, L_sp = sp.symbols(\"N L\", positive=True)\n",
+    "a_0_sp, b_0_sp, c_0_sp = sp.symbols(\"a_0 b_0 c_0\")\n",
+    "alpha_0_sp = sp.Symbol(r\"\\alpha_0\")\n",
+    "first_unknowns = (a_0_sp, b_0_sp, c_0_sp, alpha_0_sp)\n",
+    "first_matrix, first_func, first_solution_set, first_solution = solve_symbolic_identity(\n",
+    "    first_identity_residual,\n",
+    "    ctx_gd_first,\n",
+    "    {\n",
+    "        \"N\": N_sp,\n",
+    "        \"L\": L_sp,\n",
+    "        \"a_0\": a_0_sp,\n",
+    "        \"b_0\": b_0_sp,\n",
+    "        \"c_0\": c_0_sp,\n",
+    "        \"alpha_0\": alpha_0_sp,\n",
+    "    },\n",
+    "    first_unknowns,\n",
+    ")\n",
+    "\n",
+    "display_solution(\"Solution for the first transition:\", first_solution)\n",
+    "alpha_0_formula = exact_simplify(\n",
+    "    L_sp / sp.S(2) * (2 * N_sp + 1) / (2 * N_sp) * (sp.S(1) / (2 * N_sp) + sp.S(0))\n",
+    ")\n",
+    "print(\n",
+    "    \"alpha_0 matches closed-form alpha formula?\",\n",
+    "    exact_simplify(first_solution[alpha_0_sp] - alpha_0_formula) == 0,\n",
+    ")\n",
+    "first_matrix_residual, first_func_residual = residual_after_substitution(\n",
+    "    first_matrix, first_func, first_solution\n",
+    ")\n",
+    "display_verification(first_matrix_residual, first_func_residual)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1e78019",
+   "metadata": {},
+   "source": [
+    "### Case 2: $0\\le k\\le N-2$\n",
+    "\n",
+    "### We solve $\\widetilde V_k-\\widetilde V_{k+1} = -\\lambda_{k,k+1} I_{k,k+1} - \\lambda_{\\star,k+1} I_{\\star,k+1} + \\alpha_{k+1}\\|s_{k+1}\\|^2$. The linear system yields a rank-1 solution family, and consistency of the formula for $b_k, b_{k+1}$ uniquely determines the closed form for all coefficients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "dea69f48",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parametric solution for the interior transition:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\begin{aligned}a_{k} = - \\frac{k + 1}{- 2 N + k}\\\\b_{k} = \\frac{k + 1}{2 L \\left(- 2 N + k\\right)}\\\\c_{k} = \\frac{- 4 L N^{2} + 2 L N k - 2 L N + L k + 8 N^{2} \\alpha_{k+1} - 8 N \\alpha_{k+1} k - 8 N \\alpha_{k+1} + 2 \\alpha_{k+1} k^{2} + 4 \\alpha_{k+1} k + 2 \\alpha_{k+1}}{2 \\left(- 2 N + k\\right)^{2} \\left(- 2 N + k + 1\\right)}\\\\a_{k+1} = - \\frac{k + 2}{- 2 N + k + 1}\\\\b_{k+1} = - \\frac{L k + L - 4 N \\alpha_{k+1} + 2 \\alpha_{k+1} k + 2 \\alpha_{k+1}}{2 L^{2} \\left(- 2 N + k\\right)}\\\\c_{k+1} = \\frac{2 L N + L - 4 N \\alpha_{k+1} + 2 \\alpha_{k+1} k + 2 \\alpha_{k+1}}{2 \\left(- 2 N + k\\right) \\left(- 2 N + k + 1\\right)}\\\\\\text{True}\\end{aligned}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Closed form selected by consistency of b_{k+1}:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\begin{aligned}a_{k} = - \\frac{k + 1}{- 2 N + k}\\\\b_{k} = \\frac{k + 1}{2 L \\left(- 2 N + k\\right)}\\\\c_{k} = - \\frac{L \\left(- 2 N + 2 k + 1\\right)}{2 \\left(- 2 N + k\\right)^{2}}\\\\a_{k+1} = - \\frac{k + 2}{- 2 N + k + 1}\\\\b_{k+1} = \\frac{k + 2}{2 L \\left(- 2 N + k + 1\\right)}\\\\c_{k+1} = - \\frac{L \\left(- 2 N + 2 k + 3\\right)}{2 \\left(- 2 N + k + 1\\right)^{2}}\\\\\\alpha_{k+1} = - \\frac{L \\left(- 4 N k - 6 N + 2 k^{2} + 4 k + 1\\right)}{2 \\left(- 2 N + k + 1\\right)^{2}}\\end{aligned}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alpha_{k+1} matches closed-form alpha formula? True\n",
+      "quadratic residual:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "function-value residual:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0\\\\0\\\\0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0],\n",
+       "[0],\n",
+       "[0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "identity verified? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctx_gd_interior = pf.PEPContext(\"gd_interior_solve\").set_as_current()\n",
+    "N_param = pf.Parameter(\"N\")\n",
+    "k_param = pf.Parameter(\"k\")\n",
+    "f.set_stationary_point(\"x_star\")\n",
+    "x_star_int = ctx_gd_interior[\"x_star\"]\n",
+    "x_k = pf.Vector(is_basis=True, tags=[\"x_k\"])\n",
+    "x_k1 = x_k - 1 / L * f.grad(x_k)\n",
+    "x_k1.add_tag(\"x_{k+1}\")\n",
+    "x_k2 = x_k1 - 1 / L * f.grad(x_k1)\n",
+    "x_k2.add_tag(\"x_{k+2}\")\n",
+    "\n",
+    "a_k = pf.Parameter(\"a_k\")\n",
+    "b_k = pf.Parameter(\"b_k\")\n",
+    "c_k = pf.Parameter(\"c_k\")\n",
+    "a_k1 = pf.Parameter(\"a_{k+1}\")\n",
+    "b_k1 = pf.Parameter(\"b_{k+1}\")\n",
+    "c_k1 = pf.Parameter(\"c_{k+1}\")\n",
+    "alpha_k1 = pf.Parameter(\"alpha_{k+1}\")\n",
+    "\n",
+    "V_k_ansatz = (\n",
+    "    a_k * (f(x_k) - f(x_star_int))\n",
+    "    + b_k * f.grad(x_k) ** 2\n",
+    "    + c_k * (x_k1 - x_star_int) ** 2\n",
+    ")\n",
+    "V_k1_ansatz = (\n",
+    "    a_k1 * (f(x_k1) - f(x_star_int))\n",
+    "    + b_k1 * f.grad(x_k1) ** 2\n",
+    "    + c_k1 * (x_k2 - x_star_int) ** 2\n",
+    ")\n",
+    "\n",
+    "lambda_k_k1 = (k_param + 1) / (2 * N_param - k_param)\n",
+    "lambda_star_k1 = (k_param + 2) / (2 * N_param - k_param - 1) - lambda_k_k1\n",
+    "s_k1 = 1 / L * f.grad(x_k1) - 1 / (2 * N_param - k_param) * (x_k1 - x_star_int)\n",
+    "\n",
+    "interior_identity_residual = (\n",
+    "    V_k_ansatz\n",
+    "    - V_k1_ansatz\n",
+    "    + lambda_k_k1 * f.interp_ineq(\"x_k\", \"x_{k+1}\")\n",
+    "    + lambda_star_k1 * f.interp_ineq(\"x_star\", \"x_{k+1}\")\n",
+    "    - alpha_k1 * s_k1**2\n",
+    ")\n",
+    "\n",
+    "N_sp, k_sp, L_sp = sp.symbols(\"N k L\", positive=True)\n",
+    "(\n",
+    "    a_k_sp,\n",
+    "    b_k_sp,\n",
+    "    c_k_sp,\n",
+    "    a_k1_sp,\n",
+    "    b_k1_sp,\n",
+    "    c_k1_sp,\n",
+    ") = sp.symbols(\"a_k b_k c_k a_{k+1} b_{k+1} c_{k+1}\")\n",
+    "alpha_k1_sp = sp.Symbol(r\"\\alpha_{k+1}\")\n",
+    "interior_unknowns = (\n",
+    "    a_k_sp,\n",
+    "    b_k_sp,\n",
+    "    c_k_sp,\n",
+    "    a_k1_sp,\n",
+    "    b_k1_sp,\n",
+    "    c_k1_sp,\n",
+    "    alpha_k1_sp,\n",
+    ")\n",
+    "interior_matrix, interior_func, interior_solution_set, interior_param_solution = (\n",
+    "    solve_symbolic_identity(\n",
+    "        interior_identity_residual,\n",
+    "        ctx_gd_interior,\n",
+    "        {\n",
+    "            \"N\": N_sp,\n",
+    "            \"k\": k_sp,\n",
+    "            \"L\": L_sp,\n",
+    "            \"a_k\": a_k_sp,\n",
+    "            \"b_k\": b_k_sp,\n",
+    "            \"c_k\": c_k_sp,\n",
+    "            \"a_{k+1}\": a_k1_sp,\n",
+    "            \"b_{k+1}\": b_k1_sp,\n",
+    "            \"c_{k+1}\": c_k1_sp,\n",
+    "            \"alpha_{k+1}\": alpha_k1_sp,\n",
+    "        },\n",
+    "        interior_unknowns,\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "display_solution(\n",
+    "    \"Parametric solution for the interior transition:\", interior_param_solution\n",
+    ")\n",
+    "\n",
+    "b_k1_shifted = -(k_sp + 2) / (2 * L_sp * (2 * N_sp - k_sp - 1))\n",
+    "alpha_k1_closed = sp.solve(\n",
+    "    sp.Eq(interior_param_solution[b_k1_sp], b_k1_shifted), alpha_k1_sp\n",
+    ")[0]\n",
+    "alpha_k1_closed = exact_simplify(alpha_k1_closed)\n",
+    "\n",
+    "interior_solution = {\n",
+    "    unknown: exact_simplify(expression.subs(alpha_k1_sp, alpha_k1_closed))\n",
+    "    for unknown, expression in interior_param_solution.items()\n",
+    "}\n",
+    "\n",
+    "display_solution(\"Closed form selected by consistency of b_{k+1}:\", interior_solution)\n",
+    "alpha_k1_formula = exact_simplify(\n",
+    "    L_sp\n",
+    "    / sp.S(2)\n",
+    "    * (2 * N_sp - k_sp)\n",
+    "    / (2 * N_sp - k_sp - 1)\n",
+    "    * ((k_sp + 2) / (2 * N_sp - k_sp - 1) + (k_sp + 1) / (2 * N_sp - k_sp))\n",
+    ")\n",
+    "print(\n",
+    "    \"alpha_{k+1} matches closed-form alpha formula?\",\n",
+    "    exact_simplify(interior_solution[alpha_k1_sp] - alpha_k1_formula) == 0,\n",
+    ")\n",
+    "interior_matrix_residual, interior_func_residual = residual_after_substitution(\n",
+    "    interior_matrix, interior_func, interior_solution\n",
+    ")\n",
+    "display_verification(interior_matrix_residual, interior_func_residual)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08b93b30",
+   "metadata": {},
+   "source": [
+    "### Case 3: $k=N-1$\n",
+    "\n",
+    "### We check this case separately because the formula for $\\lambda_{\\star,N}$ is different from Case 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e40c1ad7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution for the terminal transition:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\begin{aligned}a_{N-1} = \\frac{N}{N + 1}\\\\b_{N-1} = - \\frac{N}{2 L \\left(N + 1\\right)}\\\\c_{N-1} = \\frac{L}{2 \\left(N + 1\\right)^{2}}\\\\\\alpha_{N} = \\frac{L}{2}\\end{aligned}$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alpha_N matches closed-form alpha formula? True\n",
+      "quadratic residual:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\\\0 & 0 & 0 & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0],\n",
+       "[0, 0, 0, 0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "function-value residual:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0\\\\0\\\\0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0],\n",
+       "[0],\n",
+       "[0]])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "identity verified? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "ctx_gd_last = pf.PEPContext(\"gd_last_endpoint_solve\").set_as_current()\n",
+    "N_param = pf.Parameter(\"N\")\n",
+    "f.set_stationary_point(\"x_star\")\n",
+    "x_star_last = ctx_gd_last[\"x_star\"]\n",
+    "x_Nm1 = pf.Vector(is_basis=True, tags=[\"x_{N-1}\"])\n",
+    "x_N = x_Nm1 - 1 / L * f.grad(x_Nm1)\n",
+    "x_N.add_tag(\"x_N\")\n",
+    "\n",
+    "a_Nm1 = pf.Parameter(\"a_{N-1}\")\n",
+    "b_Nm1 = pf.Parameter(\"b_{N-1}\")\n",
+    "c_Nm1 = pf.Parameter(\"c_{N-1}\")\n",
+    "alpha_N = pf.Parameter(\"alpha_N\")\n",
+    "\n",
+    "V_Nm1_ansatz = (\n",
+    "    a_Nm1 * (f(x_Nm1) - f(x_star_last))\n",
+    "    + b_Nm1 * f.grad(x_Nm1) ** 2\n",
+    "    + c_Nm1 * (x_N - x_star_last) ** 2\n",
+    ")\n",
+    "V_N_terminal = f(x_N) - f(x_star_last)\n",
+    "\n",
+    "lambda_Nm1_N = N_param / (N_param + 1)\n",
+    "lambda_star_N = sp.S(1) / (N_param + 1)\n",
+    "s_N = 1 / L * f.grad(x_N) - 1 / (N_param + 1) * (x_N - x_star_last)\n",
+    "\n",
+    "last_identity_residual = (\n",
+    "    V_Nm1_ansatz\n",
+    "    - V_N_terminal\n",
+    "    + lambda_Nm1_N * f.interp_ineq(\"x_{N-1}\", \"x_N\")\n",
+    "    + lambda_star_N * f.interp_ineq(\"x_star\", \"x_N\")\n",
+    "    - alpha_N * s_N**2\n",
+    ")\n",
+    "\n",
+    "N_sp, L_sp = sp.symbols(\"N L\", positive=True)\n",
+    "a_Nm1_sp, b_Nm1_sp, c_Nm1_sp = sp.symbols(\"a_{N-1} b_{N-1} c_{N-1}\")\n",
+    "alpha_N_sp = sp.Symbol(r\"\\alpha_N\")\n",
+    "last_unknowns = (a_Nm1_sp, b_Nm1_sp, c_Nm1_sp, alpha_N_sp)\n",
+    "last_matrix, last_func, last_solution_set, last_solution = solve_symbolic_identity(\n",
+    "    last_identity_residual,\n",
+    "    ctx_gd_last,\n",
+    "    {\n",
+    "        \"N\": N_sp,\n",
+    "        \"L\": L_sp,\n",
+    "        \"a_{N-1}\": a_Nm1_sp,\n",
+    "        \"b_{N-1}\": b_Nm1_sp,\n",
+    "        \"c_{N-1}\": c_Nm1_sp,\n",
+    "        \"alpha_N\": alpha_N_sp,\n",
+    "    },\n",
+    "    last_unknowns,\n",
+    ")\n",
+    "\n",
+    "display_solution(\"Solution for the terminal transition:\", last_solution)\n",
+    "alpha_N_formula = exact_simplify(\n",
+    "    L_sp / sp.S(2) * (N_sp + 1) / N_sp * (sp.S(0) + N_sp / (N_sp + 1))\n",
+    ")\n",
+    "print(\n",
+    "    \"alpha_N matches closed-form alpha formula?\",\n",
+    "    exact_simplify(last_solution[alpha_N_sp] - alpha_N_formula) == 0,\n",
+    ")\n",
+    "last_matrix_residual, last_func_residual = residual_after_substitution(\n",
+    "    last_matrix, last_func, last_solution\n",
+    ")\n",
+    "display_verification(last_matrix_residual, last_func_residual)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47bf9d8b",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "### Summarizing the above, we obtain \n",
+    "$$\n",
+    "\\widetilde V_k=\n",
+    "\\frac{k+1}{2N-k}\\left(f(x_k)-f(x_\\star)-\\frac{1}{2L}\\|\\nabla f(x_k)\\|^2\\right)\n",
+    "+\\frac{L}{2}\\frac{2N-2k-1}{(2N-k)^2}\\|x_{k+1}-x_\\star\\|^2\n",
+    "$$\n",
+    "### for $0\\le k\\le N-1$, together with $\\widetilde V_{-1}=\\frac{L}{4N+2}\\|x_0-x_\\star\\|^2$ and $\\widetilde V_N=f(x_N)-f(x_\\star)$, is a Lyapunov function."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pepflow (3.11.13.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples_lyapunov/gd/gd_example_lyap.ipynb
+++ b/examples_lyapunov/gd/gd_example_lyap.ipynb
@@ -35,11 +35,7 @@
     "import itertools\n",
     "from IPython.display import display, Math\n",
     "\n",
-    "from pepflow.lyapunov_utils import (\n",
-    "    vectors_in_column_space,\n",
-    "    find_basis_with_sparsest_coefficients,\n",
-    "    ldl_decompose_with_reversed_basis,\n",
-    ")"
+    "import pepflow.lyapunov_utils as lu"
    ]
   },
   {
@@ -314,7 +310,7 @@
     "x_0 = ctx_prf[\"x_0\"]\n",
     "x_star = ctx_prf[\"x_star\"]\n",
     "\n",
-    "D, ell = ldl_decompose_with_reversed_basis(\n",
+    "D, ell = lu.ldl_decompose_with_reversed_basis(\n",
     "    S_sol, ctx_prf.basis_vectors(), print_output=True\n",
     ")\n",
     "\n",
@@ -564,7 +560,7 @@
     "for idx, V in enumerate(V_raw):\n",
     "    print(\n",
     "        f\"V_{idx - 1}:\",\n",
-    "        vectors_in_column_space(\n",
+    "        lu.vectors_in_column_space(\n",
     "            V,\n",
     "            lyap_basis_candidate,\n",
     "            ctx_prf,\n",
@@ -684,7 +680,7 @@
    ],
    "source": [
     "for idx in range(2, len(V_raw) - 1):\n",
-    "    aligned_special_vectors = vectors_in_column_space(\n",
+    "    aligned_special_vectors = lu.vectors_in_column_space(\n",
     "        V_raw[idx],\n",
     "        lyap_basis_candidate,\n",
     "        ctx_prf,\n",
@@ -692,7 +688,7 @@
     "        rtol=1e-5,\n",
     "        atol=1e-5,\n",
     "    )\n",
-    "    best_vectors, best_coefficients = find_basis_with_sparsest_coefficients(\n",
+    "    best_vectors, best_coefficients = lu.find_basis_with_sparsest_coefficients(\n",
     "        V_raw[idx],\n",
     "        aligned_special_vectors,\n",
     "        pep_context=ctx_prf,\n",
@@ -1040,7 +1036,7 @@
    ],
    "source": [
     "for idx in range(len(lyap)):\n",
-    "    aligned_special_vectors = vectors_in_column_space(\n",
+    "    aligned_special_vectors = lu.vectors_in_column_space(\n",
     "        lyap[idx],\n",
     "        lyap_basis_candidate,\n",
     "        ctx_prf,\n",
@@ -1057,7 +1053,7 @@
     "        print(\"No candidate vector detected\")\n",
     "        continue\n",
     "    else:\n",
-    "        best_vectors, best_coefficients = find_basis_with_sparsest_coefficients(\n",
+    "        best_vectors, best_coefficients = lu.find_basis_with_sparsest_coefficients(\n",
     "            lyap[idx],\n",
     "            aligned_special_vectors,\n",
     "            pep_context=ctx_prf,\n",

--- a/pepflow/lyapunov_utils.py
+++ b/pepflow/lyapunov_utils.py
@@ -1,0 +1,576 @@
+# Copyright: 2026 The PEPFlow Developers
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.linalg import ldl
+
+from pepflow import expression_manager as exm
+from pepflow import ipython_utils
+from pepflow import pep_context as pc
+from pepflow import utils
+from pepflow.pep_result import MatrixWithNames
+
+if TYPE_CHECKING:
+    from pepflow.scalar import Scalar
+    from pepflow.vector import Vector
+
+
+def vectors_in_column_space(
+    V: np.ndarray,
+    vecs: list[Vector],
+    pep_context: pc.PEPContext | None = None,
+    *,
+    resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
+    rtol: float = 1e-7,
+    atol: float = 1e-7,
+) -> list[Vector]:
+    """Collect vectors that lie in the column space of ``V``.
+
+    Args:
+        V (np.ndarray): Matrix representation of the quadratic form.
+        vecs (list[:class:`Vector`]): Candidate vectors to test for membership
+            in ``col(V)``.
+        pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
+            we consider. `None` if we consider the current global
+            :class:`PEPContext` object.
+        resolve_parameters (dict[str, :class:`NUMERICAL_TYPE`] | None): A
+            dictionary that maps the name of parameters to the numerical values.
+        rtol (float): Relative tolerance for numerical checks.
+        atol (float): Absolute tolerance for numerical checks.
+
+    Returns:
+        list[:class:`Vector`]: Vectors that lie in ``col(V)`` within the given
+        tolerances.
+    """
+    if pep_context is None:
+        pep_context = pc.get_current_context()
+    if pep_context is None:
+        raise RuntimeError("Did you forget to create a context?")
+    pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
+    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+
+    # Build an orthonormal basis for the column space of V.
+    U, singular_values, _ = np.linalg.svd(V_coords, full_matrices=False)
+    tol = atol + rtol * singular_values[0]
+    rank = np.sum(singular_values > tol)
+    column_space_basis = U[:, :rank]
+
+    # Detect column-space membership using projection residuals.
+    vector_coords = np.column_stack(
+        [np.asarray(pm.eval_vector(v).coords, dtype=float) for v in vecs]
+    )
+    projections = column_space_basis @ (column_space_basis.T @ vector_coords)
+    residuals = np.linalg.norm(vector_coords - projections, axis=0)
+    vector_norms = np.linalg.norm(vector_coords, axis=0)
+    is_in_column_space = residuals <= atol + rtol * vector_norms
+
+    collected_column_space_vectors = [
+        vec for vec, in_column_space in zip(vecs, is_in_column_space) if in_column_space
+    ]
+    return collected_column_space_vectors
+
+
+def select_independent_subset(
+    vecs: list[Vector],
+    pep_context: pc.PEPContext | None = None,
+    *,
+    resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
+    tol: float = 1e-7,
+) -> tuple[list[Vector], list[int]]:
+    """Select linearly independent vectors in input order using greedy Gram-Schmidt.
+
+    Args:
+        vecs (list[:class:`Vector`]): Candidate vectors.
+        pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
+            we consider. `None` if we consider the current global
+            :class:`PEPContext` object.
+        resolve_parameters (dict[str, :class:`NUMERICAL_TYPE`] | None): A
+            dictionary that maps the name of parameters to the numerical values.
+        tol (float): Relative tolerance for independence checks.
+
+    Returns:
+        tuple[list[Vector], list[int]]: The selected vectors and their indices in
+        ``vecs``.
+
+    Example:
+        >>> import pepflow as pf
+        >>> ctx = pf.PEPContext("ctx").set_as_current()
+        >>> e1 = pf.Vector(is_basis=True, tags=["e_1"])
+        >>> e2 = pf.Vector(is_basis=True, tags=["e_2"])
+        >>> selected, _ = select_independent_subset(
+        ...     [e1, 2 * e1, e1 + e2, e2], pep_context=ctx
+        ... )
+        >>> selected == [e1, e1 + e2]
+        True
+    """
+    if pep_context is None:
+        pep_context = pc.get_current_context()
+    if pep_context is None:
+        raise RuntimeError("Did you forget to create a context?")
+    pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
+
+    orthonormal_basis = []
+    selected = []
+    idx = []
+
+    for i, v in enumerate(vecs):
+        v_coords = np.asarray(pm.eval_vector(v).coords, dtype=float)
+        v_norm = np.linalg.norm(v_coords)
+        if v_norm == 0:
+            continue
+
+        # Remove components already spanned by selected vectors.
+        r = v_coords.copy()
+        for basis_vec in orthonormal_basis:
+            r -= basis_vec * (basis_vec @ r)
+
+        # Select vectors with a non-negligible residual direction.
+        r_norm = np.linalg.norm(r)
+        if r_norm > tol * v_norm:
+            new_basis_vec = r / r_norm
+            orthonormal_basis.append(new_basis_vec)
+            selected.append(v)
+            idx.append(i)
+
+    return selected, idx
+
+
+def find_symmetric_coefficient_matrix(
+    V: Scalar,
+    vecs: list[Vector],
+    pep_context: pc.PEPContext | None = None,
+    *,
+    resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
+    indep_tol: float = 1e-7,
+) -> np.ndarray:
+    """Find the symmetric coefficient matrix representing ``V`` over ``vecs``.
+
+    Finds a coefficient matrix ``A`` such that
+
+    .. math:: V \\approx [v_1 \\; \\cdots \\; v_m] A [v_1 \\; \\cdots \\; v_m]^\\top.
+
+    Equivalently, finds ``A[i, j]`` such that
+
+    .. math:: V \\approx \\sum_{i \\le j} A_{ij} B_{ij},
+
+    where
+
+    .. math:: B_{ii} = v_i v_i^\\top,\\quad B_{ij} = v_i v_j^\\top + v_j v_i^\\top \\quad (i < j).
+
+    Args:
+        V (:class:`Scalar`): Symmetric scalar expression with
+            ``inner_prod_coords``.
+        vecs (list[:class:`Vector`]): Vector list used to build the
+            decomposition basis.
+        pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
+            we consider. `None` if we consider the current global
+            :class:`PEPContext` object.
+        resolve_parameters (dict[str, :class:`NUMERICAL_TYPE`] | None): A
+            dictionary that maps the name of parameters to the numerical values.
+        indep_tol (float): Tolerance for linear-independence rank checks of ``vecs``.
+
+    Raises:
+        ValueError: If inputs have incompatible shapes or ``vecs`` are linearly
+            dependent.
+
+    Returns:
+        np.ndarray: Symmetric coefficient matrix.
+    """
+    if pep_context is None:
+        pep_context = pc.get_current_context()
+    if pep_context is None:
+        raise RuntimeError("Did you forget to create a context?")
+    pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
+
+    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+    vecs_coords = [
+        np.asarray(pm.eval_vector(u).coords, dtype=float).ravel() for u in vecs
+    ]
+
+    return _find_symmetric_coefficient_matrix_from_coords(
+        V_coords,
+        vecs_coords,
+        indep_tol=indep_tol,
+    )
+
+
+def _find_symmetric_coefficient_matrix_from_coords(
+    V_coords: np.ndarray,
+    vecs: list[np.ndarray],
+    *,
+    indep_tol: float = 1e-7,
+) -> np.ndarray:
+    """Numerical backend for symmetric decomposition from pre-evaluated coords."""
+    m = len(vecs)
+
+    # Require an independent vector basis for the coefficient matrix
+    rank = np.linalg.matrix_rank(np.stack(vecs, axis=1), tol=indep_tol)
+    if rank < m:
+        raise ValueError(
+            f"vecs are linearly dependent: {m} vectors but rank is {rank}."
+        )
+
+    # Build flattened symmetric outer-product basis matrices
+    flattened_basis = []
+    coef_indices = []
+    for i in range(m):
+        for j in range(i, m):
+            basis_matrix = np.outer(vecs[i], vecs[j])
+            if i != j:
+                basis_matrix = basis_matrix + basis_matrix.T
+            flattened_basis_matrix = basis_matrix.reshape(-1)
+            flattened_basis.append(flattened_basis_matrix)
+            coef_indices.append((i, j))
+
+    # Solve the vectorized least-squares problem for the coefficients
+    stacked_basis = np.stack(flattened_basis, axis=1)
+    V_flattened = V_coords.reshape(-1)
+    coeffs, *_ = np.linalg.lstsq(stacked_basis, V_flattened, rcond=None)
+
+    # Place solved coefficients back into a symmetric matrix
+    coeff_matrix = np.zeros((m, m))
+    for (i, j), c in zip(coef_indices, coeffs):
+        coeff_matrix[i, j] = c
+        coeff_matrix[j, i] = c
+    return coeff_matrix
+
+
+def find_basis_with_sparsest_coefficients(
+    V: Scalar,
+    vecs: list[Vector],
+    *,
+    pep_context: pc.PEPContext | None = None,
+    resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
+    fixed_vectors: list[Vector] | None = None,
+    zero_tol: float = 1e-6,
+    indep_tol: float = 1e-7,
+) -> tuple[list[Vector], np.ndarray]:
+    """Find a basis whose coefficient matrix represents ``V`` most sparsely.
+
+    Among linearly independent subsets of size ``rank(vecs)``, this function
+    finds a subset whose coefficient matrix has the maximum number of zero entries.
+
+    Args:
+        V (:class:`Scalar`): Symmetric scalar expression with
+            ``inner_prod_coords``.
+        vecs (list[:class:`Vector`]): Candidate vectors used for subset search.
+        pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
+            we consider. `None` if we consider the current global
+            :class:`PEPContext` object.
+        resolve_parameters (dict[str, :class:`NUMERICAL_TYPE`] | None):
+            A dictionary that maps the name of parameters to the numerical values.
+        fixed_vectors (list[:class:`Vector`] | None): Vectors that must be
+            included in every searched subset. Each vector must be present in
+            ``vecs``.
+        zero_tol (float): Absolute threshold for counting near-zero
+            coefficients.
+        indep_tol (float): Tolerance for linear-independence rank checks.
+
+    Returns:
+        tuple[list[Vector], np.ndarray]: A best basis and its sparsest
+        symmetric coefficient matrix.
+    """
+    if pep_context is None:
+        pep_context = pc.get_current_context()
+    if pep_context is None:
+        raise RuntimeError("Did you forget to create a context?")
+    pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
+
+    if not vecs:
+        return [], np.zeros((0, 0))
+
+    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+    vecs_coords = [
+        np.asarray(pm.eval_vector(u).coords, dtype=float).ravel() for u in vecs
+    ]
+    rank = np.linalg.matrix_rank(np.stack(vecs_coords, axis=1), tol=indep_tol)
+    fixed_vectors = fixed_vectors or []
+
+    # Find fixed-vector indices for constrained subset search
+    fixed_idx: list[int] = []
+    if fixed_vectors:
+        idx_by_id = {id(v): i for i, v in enumerate(vecs)}
+
+        # Validate that every fixed vector is available in the input vectors
+        not_in_vecs = [v for v in fixed_vectors if id(v) not in idx_by_id]
+        if not_in_vecs:
+            not_in_vecs_str = ", ".join(str(v) for v in not_in_vecs)
+            raise ValueError(
+                f"`fixed_vectors` must be contained in `vecs`. Missing: {not_in_vecs_str}"
+            )
+
+        # Collect fixed-vector indices
+        seen_idx = set()
+        for v in fixed_vectors:
+            i = idx_by_id[id(v)]
+            if i not in seen_idx:
+                seen_idx.add(i)
+                fixed_idx.append(i)
+
+    if len(fixed_idx) > rank:
+        raise ValueError(
+            f"Too many fixed vectors: {len(fixed_idx)} > rank(vecs)={rank}."
+        )
+
+    best_basis: list[Vector] = []
+    sparsest_coeff_matrix = np.zeros((0, 0))
+    max_zeros = -1
+
+    fixed_idx_set = set(fixed_idx)
+    free_idx = [i for i in range(len(vecs)) if i not in fixed_idx_set]
+    num_free_to_pick = rank - len(fixed_idx)
+
+    # Search all feasible bases and keep the one with the sparsest coefficients
+    for picked_free in combinations(free_idx, num_free_to_pick):
+        idx = tuple(sorted(fixed_idx + list(picked_free)))
+        candidate_basis = [vecs[i] for i in idx]
+        candidate_basis_coords = [vecs_coords[i] for i in idx]
+
+        # Skip subsets that do not span the same space as the input vectors
+        candidate_rank = np.linalg.matrix_rank(
+            np.stack(candidate_basis_coords, axis=1), tol=indep_tol
+        )
+        if candidate_rank < rank:
+            continue
+
+        # Sparsity score: count near-zero entries in the coefficient matrix
+        coeff_matrix = _find_symmetric_coefficient_matrix_from_coords(
+            V_coords,
+            candidate_basis_coords,
+            indep_tol=indep_tol,
+        )
+        num_zeros = int(np.sum(np.abs(coeff_matrix) < zero_tol))
+
+        # Update the best basis
+        if num_zeros > max_zeros:
+            max_zeros = num_zeros
+            best_basis = candidate_basis
+            sparsest_coeff_matrix = coeff_matrix
+
+    if max_zeros < 0 and fixed_vectors:
+        fixed_s = ", ".join(str(v) for v in fixed_vectors)
+        raise ValueError(
+            f"No feasible independent subset satisfies `fixed_vectors`: {fixed_s}"
+        )
+
+    return best_basis, sparsest_coeff_matrix
+
+
+def complete_basis_with_sparsifying_last_vector(
+    V: Scalar,
+    fixed_basis_vectors: list[Vector],
+    pep_context: pc.PEPContext | None = None,
+    *,
+    resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
+    rtol: float = 1e-10,
+    normalize_last: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Complete a basis with a vector that sparsifies the coefficient matrix.
+
+    Given fixed columns ``fixed_basis_vectors = [v_1, ..., v_{r-1}]``, this
+    routine chooses a final vector ``v_r`` in ``col(V)`` and may
+    shift it by a linear combination of ``fixed_basis_vectors`` to eliminate the
+    last off-diagonal block of the coefficient matrix when possible.
+
+    Args:
+        V (:class:`Scalar`): Symmetric scalar expression with
+            ``inner_prod_coords``.
+        fixed_basis_vectors (list[:class:`Vector`]): Fixed basis vectors.
+        pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
+            we consider. `None` if we consider the current global
+            :class:`PEPContext` object.
+        resolve_parameters (dict[str, :class:`NUMERICAL_TYPE`] | None): A
+            dictionary that maps the name of parameters to the numerical values.
+        rtol (float): Relative numerical tolerance.
+        normalize_last (bool): If ``True``, rescale the final vector so the
+            last diagonal coefficient becomes ``+1`` or ``-1``.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: The adjusted final vector and the
+        updated coefficient matrix.
+    """
+    if pep_context is None:
+        pep_context = pc.get_current_context()
+    if pep_context is None:
+        raise RuntimeError("Did you forget to create a context?")
+    pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
+
+    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+    fixed_basis_matrix = np.stack(
+        [
+            np.asarray(pm.eval_vector(v).coords, dtype=float).ravel()
+            for v in fixed_basis_vectors
+        ],
+        axis=1,
+    )
+
+    def _orthonormal_column_basis(A: np.ndarray) -> np.ndarray:
+        """Orthonormal basis for col(A) via SVD."""
+        U, singular_values, _ = np.linalg.svd(A, full_matrices=False)
+        if singular_values.size == 0:
+            return np.zeros((A.shape[0], 0))
+        tol = rtol * singular_values[0]
+        rank = int(np.sum(singular_values > tol))
+        return U[:, :rank]
+
+    num_fixed = fixed_basis_matrix.shape[1]
+    rank = num_fixed + 1
+
+    # Build an orthonormal basis for col(V)
+    range_basis = _orthonormal_column_basis(V_coords)
+    if range_basis.shape[1] != rank:
+        raise ValueError(
+            f"col(V) dimension is {range_basis.shape[1]}, "
+            f"expected r={rank}. Adjust rtol or check inputs."
+        )
+
+    # Check that fixed vectors lie in col(V)
+    projected_fixed = range_basis @ (range_basis.T @ fixed_basis_matrix)
+    projection_residual = np.linalg.norm(
+        fixed_basis_matrix - projected_fixed, ord="fro"
+    ) / max(np.linalg.norm(fixed_basis_matrix, ord="fro"), 1.0)
+    if projection_residual > 1e3 * rtol:
+        raise ValueError(
+            "Columns of fixed_basis_vectors are not in col(V) "
+            f"(projection residual ratio {projection_residual:.2e})."
+        )
+
+    # Build an orthonormal basis for the fixed-vector span and check independence
+    fixed_orthonormal_basis = _orthonormal_column_basis(projected_fixed)
+    if fixed_orthonormal_basis.shape[1] != num_fixed:
+        raise ValueError(
+            "fixed_basis_vectors columns appear dependent (numerically) inside col(V)."
+        )
+
+    # Pick the final direction in col(V) to complete the basis
+    range_complement = range_basis - fixed_orthonormal_basis @ (
+        fixed_orthonormal_basis.T @ range_basis
+    )
+    complement_basis = _orthonormal_column_basis(range_complement)
+    initial_last_vector = complement_basis[:, 0]
+
+    # Compute the coefficient matrix for the completed basis
+    completed_basis_vectors = [fixed_basis_matrix[:, i] for i in range(num_fixed)] + [
+        initial_last_vector
+    ]
+    coeff_matrix = _find_symmetric_coefficient_matrix_from_coords(
+        V_coords,
+        completed_basis_vectors,
+        indep_tol=rtol,
+    )
+
+    cross_coeffs = coeff_matrix[:-1, -1]
+    last_coeff = coeff_matrix[-1, -1]
+
+    # Sparsify by shifting only the last vector
+    if abs(last_coeff) <= rtol:
+        # If the last coefficient is zero, the restricted shift cannot remove cross terms
+        sparsifying_last_vector = initial_last_vector
+        block_diag_coeff_matrix = coeff_matrix
+    else:
+        # Otherwise choose a shift that eliminates the last cross-block
+        shift_coeffs = cross_coeffs / last_coeff
+        sparsifying_last_vector = (
+            initial_last_vector + fixed_basis_matrix @ shift_coeffs
+        )
+
+        fixed_block = coeff_matrix[:-1, :-1]
+        shifted_fixed_block = (
+            fixed_block - np.outer(cross_coeffs, cross_coeffs) / last_coeff
+        )
+        block_diag_coeff_matrix = np.zeros((rank, rank), dtype=float)
+        block_diag_coeff_matrix[:-1, :-1] = shifted_fixed_block
+        block_diag_coeff_matrix[-1, -1] = last_coeff
+
+        # Optionally normalize the last coefficient to +/-1
+        if normalize_last:
+            last_vector_scale = np.sqrt(abs(block_diag_coeff_matrix[-1, -1]))
+            sparsifying_last_vector = sparsifying_last_vector * last_vector_scale
+            block_diag_coeff_matrix[-1, -1] = np.sign(block_diag_coeff_matrix[-1, -1])
+
+    return sparsifying_last_vector, block_diag_coeff_matrix
+
+
+def ldl_decompose_with_reversed_basis(
+    S: MatrixWithNames, basis: list[Vector], print_output: bool = True
+) -> tuple[np.ndarray, list[Vector]]:
+    """Run LDL on a reversed-basis matrix and return labeled factors.
+
+    This routine assumes the input basis and matrix labels follow the same
+    "earlier iterates first" convention. It reverses both orders, runs LDL,
+    and applies LDL permutation to labels/basis when needed.
+
+    Args:
+        S (:class:`MatrixWithNames`): Named symmetric matrix to decompose.
+        basis (list[:class:`Vector`]): Basis vectors aligned with ``S.row_names``.
+        print_output (bool): Whether to pretty-print ``L^T`` (labeled) and ``D``.
+
+    Raises:
+        ValueError: If reversed basis labels do not match reversed matrix labels.
+
+    Returns:
+        tuple[np.ndarray, list[:class:`Vector`]]: The diagonal/block-diagonal
+        matrix ``D`` from LDL and the linear forms ``ell`` built from rows of
+        the labeled transpose of the LDL lower factor.
+    """
+    # Assuming the original basis is ordered by gradients at earlier iterates first,
+    # reverse the basis order so gradients at later iterates appear first.
+    S_reversed = S.matrix[::-1, :][:, ::-1]
+    names_rev = S.row_names[::-1]
+    reversed_basis = basis[::-1]
+
+    # Check that matrix labels and basis vectors stay aligned
+    basis_names_rev = [repr(v) for v in reversed_basis]
+    if names_rev != basis_names_rev:
+        raise ValueError(
+            "Reversed matrix labels and reversed basis labels do not match. "
+            f"names_rev={names_rev}, basis_names_rev={basis_names_rev}"
+        )
+
+    # Apply any LDL permutation consistently to factors, labels, and basis
+    lower_factor, D, perm = ldl(S_reversed)
+    perm = np.asarray(perm, dtype=int)
+    if not np.array_equal(perm, np.arange(len(perm))):
+        lower_factor = lower_factor[perm, :]
+        names_rev = [names_rev[i] for i in perm]
+        reversed_basis = [reversed_basis[i] for i in perm]
+
+    # Build the linear forms from rows of the transposed lower factor
+    lower_factor_T = lower_factor.T
+    ell = [
+        lower_factor_T[i, :].T @ reversed_basis for i in range(lower_factor_T.shape[0])
+    ]
+
+    # Optionally display the labeled LDL factors
+    if print_output:
+        row_labels = [rf"\ell_{{{i + 1}}}" for i in range(lower_factor.shape[0])]
+        labeled_lower_factor_T = MatrixWithNames(
+            matrix=lower_factor_T,
+            row_names=row_labels,
+            col_names=names_rev,
+        )
+        labeled_lower_factor_T.pprint()
+        ipython_utils.pprint_matrix(D)
+
+    return D, ell

--- a/pepflow/lyapunov_utils.py
+++ b/pepflow/lyapunov_utils.py
@@ -19,13 +19,13 @@
 
 from __future__ import annotations
 
+import itertools
+import math
 import warnings
-from itertools import combinations
-from math import comb
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.linalg import ldl
+import scipy.linalg
 
 from pepflow import expression_manager as exm
 from pepflow import ipython_utils
@@ -36,6 +36,22 @@ from pepflow.pep_result import MatrixWithNames
 if TYPE_CHECKING:
     from pepflow.scalar import Scalar
     from pepflow.vector import Vector
+
+
+def _eval_scalar_inner_prod_coords(
+    V: Scalar,
+    pm: exm.ExpressionManager,
+) -> np.ndarray:
+    """Evaluate the inner-product coordinate matrix of a scalar expression."""
+    return np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+
+
+def _eval_vectors_coords(
+    vecs: list[Vector],
+    pm: exm.ExpressionManager,
+) -> list[np.ndarray]:
+    """Evaluate vectors as one-dimensional coordinate arrays."""
+    return [np.asarray(pm.eval_vector(v).coords, dtype=float).ravel() for v in vecs]
 
 
 def vectors_in_column_space(
@@ -74,7 +90,7 @@ def vectors_in_column_space(
     if pep_context is None:
         raise RuntimeError("Did you forget to create a context?")
     pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
-    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+    V_coords = _eval_scalar_inner_prod_coords(V, pm)
 
     # Build an orthonormal basis for the column space of V.
     U, singular_values, _ = np.linalg.svd(V_coords, full_matrices=False)
@@ -84,9 +100,7 @@ def vectors_in_column_space(
     column_space_basis = U[:, :rank]
 
     # Detect column-space membership using projection residuals.
-    vector_coords = np.column_stack(
-        [np.asarray(pm.eval_vector(v).coords, dtype=float) for v in vecs]
-    )
+    vector_coords = np.column_stack(_eval_vectors_coords(vecs, pm))
     projections = column_space_basis @ (column_space_basis.T @ vector_coords)
     residuals = np.linalg.norm(vector_coords - projections, axis=0)
     vector_norms = np.linalg.norm(vector_coords, axis=0)
@@ -145,13 +159,13 @@ def select_independent_subset(
     idx = []
 
     for i, v in enumerate(vecs):
-        v_coords = np.asarray(pm.eval_vector(v).coords, dtype=float)
-        v_norm = np.linalg.norm(v_coords)
+        vec_coords = np.asarray(pm.eval_vector(v).coords, dtype=float)
+        v_norm = np.linalg.norm(vec_coords)
         if v_norm == 0:
             continue
 
         # Remove components already spanned by selected vectors.
-        r = v_coords.copy()
+        r = vec_coords.copy()
         for basis_vec in orthonormal_basis:
             r -= basis_vec * (basis_vec @ r)
 
@@ -217,14 +231,12 @@ def find_symmetric_coefficient_matrix(
         raise RuntimeError("Did you forget to create a context?")
     pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
 
-    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
-    vecs_coords = [
-        np.asarray(pm.eval_vector(u).coords, dtype=float).ravel() for u in vecs
-    ]
+    V_coords = _eval_scalar_inner_prod_coords(V, pm)
+    vec_coords = _eval_vectors_coords(vecs, pm)
 
     return _find_symmetric_coefficient_matrix_from_coords(
         V_coords,
-        vecs_coords,
+        vec_coords,
         indep_tol=indep_tol,
         span_tol=span_tol,
     )
@@ -232,24 +244,24 @@ def find_symmetric_coefficient_matrix(
 
 def _find_symmetric_coefficient_matrix_from_coords(
     V_coords: np.ndarray,
-    vecs: list[np.ndarray],
+    vec_coords: list[np.ndarray],
     *,
     indep_tol: float = 1e-7,
     span_tol: float = 1e-5,
 ) -> np.ndarray:
     """Numerical backend for symmetric decomposition from pre-evaluated coords."""
-    num_vecs = len(vecs)
+    num_vecs = len(vec_coords)
 
-    # Handle the empty-basis case before stacking vecs.
+    # Handle the empty-basis case before stacking vec_coords.
     if num_vecs == 0:
         if np.linalg.norm(V_coords, ord="fro") > span_tol:
             raise ValueError("The columns of V_coords are not contained in span(vecs).")
         return np.zeros((0, 0))
 
-    vecs_matrix = np.stack(vecs, axis=1)
+    vecs_matrix = np.stack(vec_coords, axis=1)
     vecs_rank = np.linalg.matrix_rank(vecs_matrix, tol=indep_tol)
 
-    # Check whether the columns of V_coords lie in span(vecs).
+    # Check whether the columns of V_coords lie in span(vec_coords).
     projection_coeffs, *_ = np.linalg.lstsq(vecs_matrix, V_coords, rcond=None)
     projection_residual = np.linalg.norm(
         V_coords - vecs_matrix @ projection_coeffs, ord="fro"
@@ -337,11 +349,9 @@ def find_basis_with_sparsest_coefficients(
     if not vecs:
         return [], np.zeros((0, 0))
 
-    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
-    vecs_coords = [
-        np.asarray(pm.eval_vector(u).coords, dtype=float).ravel() for u in vecs
-    ]
-    rank = np.linalg.matrix_rank(np.stack(vecs_coords, axis=1), tol=indep_tol)
+    V_coords = _eval_scalar_inner_prod_coords(V, pm)
+    vec_coords = _eval_vectors_coords(vecs, pm)
+    rank = np.linalg.matrix_rank(np.stack(vec_coords, axis=1), tol=indep_tol)
     fixed_vectors = fixed_vectors or []
 
     # Find fixed-vector indices for constrained subset search
@@ -372,17 +382,17 @@ def find_basis_with_sparsest_coefficients(
     num_free_to_pick = rank - len(fixed_idx)
 
     # The search cost scales with the number of candidate subsets.
-    num_subsets = comb(len(free_idx), num_free_to_pick)
+    num_subsets = math.comb(len(free_idx), num_free_to_pick)
     if num_subsets > 1_000:
         warnings.warn(
             f"Exhaustive subset search may be slow: checking {num_subsets} subsets."
         )
 
     # Search all feasible bases and keep the one with the sparsest coefficients
-    for picked_free in combinations(free_idx, num_free_to_pick):
+    for picked_free in itertools.combinations(free_idx, num_free_to_pick):
         idx = tuple(sorted(fixed_idx + list(picked_free)))
         candidate_basis = [vecs[i] for i in idx]
-        candidate_basis_coords = [vecs_coords[i] for i in idx]
+        candidate_basis_coords = [vec_coords[i] for i in idx]
 
         # Skip subsets that do not span the same space as the input vectors
         candidate_rank = np.linalg.matrix_rank(
@@ -454,12 +464,9 @@ def complete_basis_with_sparsifying_last_vector(
         raise RuntimeError("Did you forget to create a context?")
     pm = exm.ExpressionManager(pep_context, resolve_parameters=resolve_parameters)
 
-    V_coords = np.asarray(pm.eval_scalar(V).inner_prod_coords, dtype=float)
+    V_coords = _eval_scalar_inner_prod_coords(V, pm)
     fixed_basis_matrix = np.stack(
-        [
-            np.asarray(pm.eval_vector(v).coords, dtype=float).ravel()
-            for v in fixed_basis_vectors
-        ],
+        _eval_vectors_coords(fixed_basis_vectors, pm),
         axis=1,
     )
 
@@ -587,7 +594,7 @@ def ldl_decompose_with_reversed_basis(
         )
 
     # Apply any LDL permutation consistently to factors, labels, and basis
-    lower_factor, D, perm = ldl(S_reversed)
+    lower_factor, D, perm = scipy.linalg.ldl(S_reversed)
     perm = np.asarray(perm, dtype=int)
     if not np.array_equal(perm, np.arange(len(perm))):
         lower_factor = lower_factor[perm, :]

--- a/pepflow/lyapunov_utils.py
+++ b/pepflow/lyapunov_utils.py
@@ -173,6 +173,7 @@ def find_symmetric_coefficient_matrix(
     *,
     resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
     indep_tol: float = 1e-7,
+    span_tol: float = 1e-5,
 ) -> np.ndarray:
     """Find the symmetric coefficient matrix for the inner-product part of ``V``.
 
@@ -200,6 +201,8 @@ def find_symmetric_coefficient_matrix(
         resolve_parameters (dict[str, :class:`NUMERICAL_TYPE`] | None): A
             dictionary that maps the name of parameters to the numerical values.
         indep_tol (float): Tolerance for linear-independence rank checks of ``vecs``.
+        span_tol (float): Tolerance for checking whether ``V`` is represented
+            by the span of ``vecs``.
 
     Raises:
         ValueError: If inputs have incompatible shapes or ``vecs`` are linearly
@@ -223,6 +226,7 @@ def find_symmetric_coefficient_matrix(
         V_coords,
         vecs_coords,
         indep_tol=indep_tol,
+        span_tol=span_tol,
     )
 
 
@@ -231,31 +235,26 @@ def _find_symmetric_coefficient_matrix_from_coords(
     vecs: list[np.ndarray],
     *,
     indep_tol: float = 1e-7,
+    span_tol: float = 1e-5,
 ) -> np.ndarray:
     """Numerical backend for symmetric decomposition from pre-evaluated coords."""
     num_vecs = len(vecs)
-    V_rank = np.linalg.matrix_rank(V_coords, tol=indep_tol)
 
     # Handle the empty-basis case before stacking vecs.
     if num_vecs == 0:
-        vecs_rank = 0
-        if V_rank > vecs_rank:
-            raise ValueError(f"rank(V_coords)={V_rank} exceeds rank(vecs)={vecs_rank}.")
+        if np.linalg.norm(V_coords, ord="fro") > span_tol:
+            raise ValueError("The columns of V_coords are not contained in span(vecs).")
         return np.zeros((0, 0))
 
     vecs_matrix = np.stack(vecs, axis=1)
     vecs_rank = np.linalg.matrix_rank(vecs_matrix, tol=indep_tol)
-
-    # A basis with too small a span cannot represent V_coords.
-    if V_rank > vecs_rank:
-        raise ValueError(f"rank(V_coords)={V_rank} exceeds rank(vecs)={vecs_rank}.")
 
     # Check whether the columns of V_coords lie in span(vecs).
     projection_coeffs, *_ = np.linalg.lstsq(vecs_matrix, V_coords, rcond=None)
     projection_residual = np.linalg.norm(
         V_coords - vecs_matrix @ projection_coeffs, ord="fro"
     )
-    if projection_residual > indep_tol * max(1.0, np.linalg.norm(V_coords, ord="fro")):
+    if projection_residual > span_tol * max(1.0, np.linalg.norm(V_coords, ord="fro")):
         raise ValueError("The columns of V_coords are not contained in span(vecs).")
 
     # Require an independent vector basis for the coefficient matrix
@@ -264,26 +263,27 @@ def _find_symmetric_coefficient_matrix_from_coords(
             f"vecs are linearly dependent: {num_vecs} vectors but rank is {vecs_rank}."
         )
 
-    # Build flattened symmetric outer-product basis matrices
-    flattened_basis = []
-    coef_indices = []
-    for i in range(num_vecs):
-        for j in range(i, num_vecs):
-            basis_matrix = np.outer(vecs[i], vecs[j])
-            if i != j:
-                basis_matrix = basis_matrix + basis_matrix.T
-            flattened_basis_matrix = basis_matrix.reshape(-1)
-            flattened_basis.append(flattened_basis_matrix)
-            coef_indices.append((i, j))
+    # Build flattened symmetric outer-product basis matrices.
+    row_idx, col_idx = np.triu_indices(num_vecs)
+    flattened_outer_products = np.einsum(
+        "ai,bj->ijab", vecs_matrix, vecs_matrix
+    ).reshape(num_vecs, num_vecs, -1)
+    flattened_basis = flattened_outer_products[row_idx, col_idx]
+
+    # Symmetrize off-diagonal basis entries: v_i v_j^T -> v_i v_j^T + v_j v_i^T.
+    off_diagonal = row_idx != col_idx
+    flattened_basis[off_diagonal] += flattened_outer_products[
+        col_idx[off_diagonal], row_idx[off_diagonal]
+    ]
 
     # Solve the vectorized least-squares problem for the coefficients
-    stacked_basis = np.stack(flattened_basis, axis=1)
+    stacked_basis = flattened_basis.T
     V_flattened = V_coords.reshape(-1)
     coeffs, *_ = np.linalg.lstsq(stacked_basis, V_flattened, rcond=None)
 
     # Place solved coefficients back into a symmetric matrix
     coeff_matrix = np.zeros((num_vecs, num_vecs))
-    for (i, j), c in zip(coef_indices, coeffs):
+    for i, j, c in zip(row_idx, col_idx, coeffs):
         coeff_matrix[i, j] = c
         coeff_matrix[j, i] = c
     return coeff_matrix
@@ -298,6 +298,7 @@ def find_basis_with_sparsest_coefficients(
     fixed_vectors: list[Vector] | None = None,
     zero_tol: float = 1e-6,
     indep_tol: float = 1e-7,
+    span_tol: float = 1e-5,
 ) -> tuple[list[Vector], np.ndarray]:
     """Find a basis whose coefficient matrix sparsely represents inner products.
 
@@ -320,6 +321,8 @@ def find_basis_with_sparsest_coefficients(
         zero_tol (float): Absolute threshold for counting near-zero
             coefficients.
         indep_tol (float): Tolerance for linear-independence rank checks.
+        span_tol (float): Tolerance for checking whether ``V`` is represented
+            by the span of each candidate basis.
 
     Returns:
         tuple[list[Vector], np.ndarray]: A best basis and its sparsest
@@ -393,6 +396,7 @@ def find_basis_with_sparsest_coefficients(
             V_coords,
             candidate_basis_coords,
             indep_tol=indep_tol,
+            span_tol=span_tol,
         )
         num_zeros = int(np.sum(np.abs(coeff_matrix) < zero_tol))
 

--- a/pepflow/lyapunov_utils.py
+++ b/pepflow/lyapunov_utils.py
@@ -19,7 +19,9 @@
 
 from __future__ import annotations
 
+import warnings
 from itertools import combinations
+from math import comb
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -37,7 +39,7 @@ if TYPE_CHECKING:
 
 
 def vectors_in_column_space(
-    V: np.ndarray,
+    V: Scalar,
     vecs: list[Vector],
     pep_context: pc.PEPContext | None = None,
     *,
@@ -48,7 +50,8 @@ def vectors_in_column_space(
     """Collect vectors that lie in the column space of ``V``.
 
     Args:
-        V (np.ndarray): Matrix representation of the quadratic form.
+        V (:class:`Scalar`): Scalar expression built from vector inner products.
+            Its evaluated matrix is used for the column-space test.
         vecs (list[:class:`Vector`]): Candidate vectors to test for membership
             in ``col(V)``.
         pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
@@ -63,6 +66,9 @@ def vectors_in_column_space(
         list[:class:`Vector`]: Vectors that lie in ``col(V)`` within the given
         tolerances.
     """
+    if not vecs:
+        return []
+
     if pep_context is None:
         pep_context = pc.get_current_context()
     if pep_context is None:
@@ -72,7 +78,8 @@ def vectors_in_column_space(
 
     # Build an orthonormal basis for the column space of V.
     U, singular_values, _ = np.linalg.svd(V_coords, full_matrices=False)
-    tol = atol + rtol * singular_values[0]
+    scale = singular_values[0] if singular_values.size else 0.0
+    tol = atol + rtol * scale
     rank = np.sum(singular_values > tol)
     column_space_basis = U[:, :rank]
 
@@ -112,6 +119,9 @@ def select_independent_subset(
     Returns:
         tuple[list[Vector], list[int]]: The selected vectors and their indices in
         ``vecs``.
+
+    Note:
+        The order of ``vecs`` matters because vectors are selected greedily.
 
     Example:
         >>> import pepflow as pf
@@ -164,9 +174,10 @@ def find_symmetric_coefficient_matrix(
     resolve_parameters: dict[str, utils.NUMERICAL_TYPE] | None = None,
     indep_tol: float = 1e-7,
 ) -> np.ndarray:
-    """Find the symmetric coefficient matrix representing ``V`` over ``vecs``.
+    """Find the symmetric coefficient matrix for the inner-product part of ``V``.
 
-    Finds a coefficient matrix ``A`` such that
+    Finds a coefficient matrix ``A`` such that the inner-product part of ``V``
+    satisfies
 
     .. math:: V \\approx [v_1 \\; \\cdots \\; v_m] A [v_1 \\; \\cdots \\; v_m]^\\top.
 
@@ -179,8 +190,8 @@ def find_symmetric_coefficient_matrix(
     .. math:: B_{ii} = v_i v_i^\\top,\\quad B_{ij} = v_i v_j^\\top + v_j v_i^\\top \\quad (i < j).
 
     Args:
-        V (:class:`Scalar`): Symmetric scalar expression with
-            ``inner_prod_coords``.
+        V (:class:`Scalar`): Scalar expression whose inner-product coefficients
+            are decomposed.
         vecs (list[:class:`Vector`]): Vector list used to build the
             decomposition basis.
         pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
@@ -222,20 +233,42 @@ def _find_symmetric_coefficient_matrix_from_coords(
     indep_tol: float = 1e-7,
 ) -> np.ndarray:
     """Numerical backend for symmetric decomposition from pre-evaluated coords."""
-    m = len(vecs)
+    num_vecs = len(vecs)
+    V_rank = np.linalg.matrix_rank(V_coords, tol=indep_tol)
+
+    # Handle the empty-basis case before stacking vecs.
+    if num_vecs == 0:
+        vecs_rank = 0
+        if V_rank > vecs_rank:
+            raise ValueError(f"rank(V_coords)={V_rank} exceeds rank(vecs)={vecs_rank}.")
+        return np.zeros((0, 0))
+
+    vecs_matrix = np.stack(vecs, axis=1)
+    vecs_rank = np.linalg.matrix_rank(vecs_matrix, tol=indep_tol)
+
+    # A basis with too small a span cannot represent V_coords.
+    if V_rank > vecs_rank:
+        raise ValueError(f"rank(V_coords)={V_rank} exceeds rank(vecs)={vecs_rank}.")
+
+    # Check whether the columns of V_coords lie in span(vecs).
+    projection_coeffs, *_ = np.linalg.lstsq(vecs_matrix, V_coords, rcond=None)
+    projection_residual = np.linalg.norm(
+        V_coords - vecs_matrix @ projection_coeffs, ord="fro"
+    )
+    if projection_residual > indep_tol * max(1.0, np.linalg.norm(V_coords, ord="fro")):
+        raise ValueError("The columns of V_coords are not contained in span(vecs).")
 
     # Require an independent vector basis for the coefficient matrix
-    rank = np.linalg.matrix_rank(np.stack(vecs, axis=1), tol=indep_tol)
-    if rank < m:
+    if vecs_rank < num_vecs:
         raise ValueError(
-            f"vecs are linearly dependent: {m} vectors but rank is {rank}."
+            f"vecs are linearly dependent: {num_vecs} vectors but rank is {vecs_rank}."
         )
 
     # Build flattened symmetric outer-product basis matrices
     flattened_basis = []
     coef_indices = []
-    for i in range(m):
-        for j in range(i, m):
+    for i in range(num_vecs):
+        for j in range(i, num_vecs):
             basis_matrix = np.outer(vecs[i], vecs[j])
             if i != j:
                 basis_matrix = basis_matrix + basis_matrix.T
@@ -249,7 +282,7 @@ def _find_symmetric_coefficient_matrix_from_coords(
     coeffs, *_ = np.linalg.lstsq(stacked_basis, V_flattened, rcond=None)
 
     # Place solved coefficients back into a symmetric matrix
-    coeff_matrix = np.zeros((m, m))
+    coeff_matrix = np.zeros((num_vecs, num_vecs))
     for (i, j), c in zip(coef_indices, coeffs):
         coeff_matrix[i, j] = c
         coeff_matrix[j, i] = c
@@ -266,14 +299,15 @@ def find_basis_with_sparsest_coefficients(
     zero_tol: float = 1e-6,
     indep_tol: float = 1e-7,
 ) -> tuple[list[Vector], np.ndarray]:
-    """Find a basis whose coefficient matrix represents ``V`` most sparsely.
+    """Find a basis whose coefficient matrix sparsely represents inner products.
 
     Among linearly independent subsets of size ``rank(vecs)``, this function
-    finds a subset whose coefficient matrix has the maximum number of zero entries.
+    finds a subset whose coefficient matrix for the inner-product part of ``V``
+    has the maximum number of zero entries.
 
     Args:
-        V (:class:`Scalar`): Symmetric scalar expression with
-            ``inner_prod_coords``.
+        V (:class:`Scalar`): Scalar expression whose inner-product coefficients
+            are decomposed.
         vecs (list[:class:`Vector`]): Candidate vectors used for subset search.
         pep_context (:class:`PEPContext` | None): The :class:`PEPContext` object
             we consider. `None` if we consider the current global
@@ -310,10 +344,8 @@ def find_basis_with_sparsest_coefficients(
     # Find fixed-vector indices for constrained subset search
     fixed_idx: list[int] = []
     if fixed_vectors:
-        idx_by_id = {id(v): i for i, v in enumerate(vecs)}
-
         # Validate that every fixed vector is available in the input vectors
-        not_in_vecs = [v for v in fixed_vectors if id(v) not in idx_by_id]
+        not_in_vecs = [v for v in fixed_vectors if v not in vecs]
         if not_in_vecs:
             not_in_vecs_str = ", ".join(str(v) for v in not_in_vecs)
             raise ValueError(
@@ -321,12 +353,7 @@ def find_basis_with_sparsest_coefficients(
             )
 
         # Collect fixed-vector indices
-        seen_idx = set()
-        for v in fixed_vectors:
-            i = idx_by_id[id(v)]
-            if i not in seen_idx:
-                seen_idx.add(i)
-                fixed_idx.append(i)
+        fixed_idx = sorted({vecs.index(v) for v in fixed_vectors})
 
     if len(fixed_idx) > rank:
         raise ValueError(
@@ -340,6 +367,13 @@ def find_basis_with_sparsest_coefficients(
     fixed_idx_set = set(fixed_idx)
     free_idx = [i for i in range(len(vecs)) if i not in fixed_idx_set]
     num_free_to_pick = rank - len(fixed_idx)
+
+    # The search cost scales with the number of candidate subsets.
+    num_subsets = comb(len(free_idx), num_free_to_pick)
+    if num_subsets > 1_000:
+        warnings.warn(
+            f"Exhaustive subset search may be slow: checking {num_subsets} subsets."
+        )
 
     # Search all feasible bases and keep the one with the sparsest coefficients
     for picked_free in combinations(free_idx, num_free_to_pick):

--- a/pepflow/lyapunov_utils_test.py
+++ b/pepflow/lyapunov_utils_test.py
@@ -121,10 +121,10 @@ def test_find_symmetric_coefficient_matrix_helper_handles_edge_cases():
 
     np.testing.assert_allclose(coeff_matrix, np.zeros((0, 0)))
 
-    with pytest.raises(ValueError, match=r"rank\(V_coords\)=1 exceeds rank\(vecs\)=0"):
+    with pytest.raises(ValueError, match="not contained in span"):
         lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(np.eye(1), [])
 
-    with pytest.raises(ValueError, match=r"rank\(V_coords\)=2 exceeds rank\(vecs\)=1"):
+    with pytest.raises(ValueError, match="not contained in span"):
         lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(
             np.eye(2), [np.array([1.0, 0.0])]
         )
@@ -140,6 +140,16 @@ def test_find_symmetric_coefficient_matrix_helper_handles_edge_cases():
             np.array([[1.0, 0.0], [0.0, 0.0]]),
             [np.array([1.0, 0.0]), np.array([2.0, 0.0])],
         )
+
+
+def test_find_symmetric_coefficient_matrix_helper_allows_tiny_residual_rank():
+    coeff_matrix = lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(
+        np.diag([2.0, 3.0, 1e-8]),
+        [np.array([1.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0])],
+    )
+
+    expected = np.array([[2.0, 0.0], [0.0, 3.0]])
+    np.testing.assert_allclose(coeff_matrix, expected, atol=1e-7)
 
 
 def test_find_basis_with_sparsest_coefficients_selects_sparse_basis(

--- a/pepflow/lyapunov_utils_test.py
+++ b/pepflow/lyapunov_utils_test.py
@@ -25,7 +25,7 @@ import pytest
 from pepflow import lyapunov_utils
 from pepflow import pep_context as pc
 from pepflow import registry as reg
-from pepflow import vector
+from pepflow import scalar, vector
 from pepflow.pep_result import MatrixWithNames
 
 
@@ -61,6 +61,30 @@ def test_vectors_in_column_space_filters_candidates(
     assert selected == [e1, two_e1]
 
 
+def test_vectors_in_column_space_handles_degenerate_cases(
+    pep_context: pc.PEPContext,
+):
+    zero_dim_V = scalar.Scalar.zero()
+
+    assert (
+        lyapunov_utils.vectors_in_column_space(zero_dim_V, [], pep_context=pep_context)
+        == []
+    )
+
+    e1 = vector.Vector(is_basis=True, tags=["e_1"])
+    zero_vector = vector.Vector.zero()
+
+    assert (
+        lyapunov_utils.vectors_in_column_space(
+            scalar.Scalar.zero(), [], pep_context=pep_context
+        )
+        == []
+    )
+    assert lyapunov_utils.vectors_in_column_space(
+        scalar.Scalar.zero(), [zero_vector, e1], pep_context=pep_context
+    ) == [zero_vector]
+
+
 def test_select_independent_subset_skips_dependent_vectors(
     pep_context: pc.PEPContext, basis_vectors
 ):
@@ -88,6 +112,34 @@ def test_find_symmetric_coefficient_matrix_recovers_known_coefficients(
 
     expected = np.array([[2.0, 1.5], [1.5, 5.0]])
     np.testing.assert_allclose(coeff_matrix, expected, atol=1e-10)
+
+
+def test_find_symmetric_coefficient_matrix_helper_handles_edge_cases():
+    coeff_matrix = lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(
+        np.zeros((0, 0)), []
+    )
+
+    np.testing.assert_allclose(coeff_matrix, np.zeros((0, 0)))
+
+    with pytest.raises(ValueError, match=r"rank\(V_coords\)=1 exceeds rank\(vecs\)=0"):
+        lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(np.eye(1), [])
+
+    with pytest.raises(ValueError, match=r"rank\(V_coords\)=2 exceeds rank\(vecs\)=1"):
+        lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(
+            np.eye(2), [np.array([1.0, 0.0])]
+        )
+
+    with pytest.raises(ValueError, match="not contained in span"):
+        lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(
+            np.array([[0.0, 0.0], [0.0, 1.0]]),
+            [np.array([1.0, 0.0])],
+        )
+
+    with pytest.raises(ValueError, match="vecs are linearly dependent"):
+        lyapunov_utils._find_symmetric_coefficient_matrix_from_coords(
+            np.array([[1.0, 0.0], [0.0, 0.0]]),
+            [np.array([1.0, 0.0]), np.array([2.0, 0.0])],
+        )
 
 
 def test_find_basis_with_sparsest_coefficients_selects_sparse_basis(
@@ -126,6 +178,22 @@ def test_find_basis_with_sparsest_coefficients_respects_fixed_vectors(
     assert e1 in basis
     assert len(basis) == 2
     assert coeff_matrix.shape == (2, 2)
+
+
+def test_find_basis_with_sparsest_coefficients_warns_for_large_subset_search(
+    pep_context: pc.PEPContext,
+):
+    e1 = vector.Vector(is_basis=True, tags=["e_1"])
+    e2 = vector.Vector(is_basis=True, tags=["e_2"])
+    basis = [e1, e2]
+    for i in range(150):
+        basis.append(e1 + (i + 1) * e2)
+    V = e1**2 + e2**2
+
+    with pytest.warns(UserWarning, match="checking 11476 subsets"):
+        lyapunov_utils.find_basis_with_sparsest_coefficients(
+            V, basis, pep_context=pep_context
+        )
 
 
 def test_complete_basis_with_sparsifying_last_vector_eliminates_last_cross_block(

--- a/pepflow/lyapunov_utils_test.py
+++ b/pepflow/lyapunov_utils_test.py
@@ -1,0 +1,161 @@
+# Copyright: 2026 The PEPFlow Developers
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Iterator
+
+import numpy as np
+import pytest
+
+from pepflow import lyapunov_utils
+from pepflow import pep_context as pc
+from pepflow import registry as reg
+from pepflow import vector
+from pepflow.pep_result import MatrixWithNames
+
+
+@pytest.fixture
+def pep_context() -> Iterator[pc.PEPContext]:
+    """Prepare the pep context and reset global state at the end."""
+
+    ctx = pc.PEPContext("test").set_as_current()
+    yield ctx
+    pc.set_current_context(None)
+    pc.GLOBAL_CONTEXT_DICT.clear()
+    reg.REGISTERED_FUNC_AND_OPER_DICT.clear()
+
+
+@pytest.fixture
+def basis_vectors(pep_context: pc.PEPContext):
+    e1 = vector.Vector(is_basis=True, tags=["e_1"])
+    e2 = vector.Vector(is_basis=True, tags=["e_2"])
+    return e1, e2
+
+
+def test_vectors_in_column_space_filters_candidates(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    two_e1 = 2 * e1
+    candidates = [e1, e2, two_e1, e1 + e2]
+
+    selected = lyapunov_utils.vectors_in_column_space(
+        e1**2, candidates, pep_context=pep_context
+    )
+
+    assert selected == [e1, two_e1]
+
+
+def test_select_independent_subset_skips_dependent_vectors(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    e1_plus_e2 = e1 + e2
+    candidates = [e1, 2 * e1, e1_plus_e2, e2]
+
+    selected, indices = lyapunov_utils.select_independent_subset(
+        candidates, pep_context=pep_context
+    )
+
+    assert selected == [e1, e1_plus_e2]
+    assert indices == [0, 2]
+
+
+def test_find_symmetric_coefficient_matrix_recovers_known_coefficients(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    V = 2 * e1**2 + 3 * (e1 * e2) + 5 * e2**2
+
+    coeff_matrix = lyapunov_utils.find_symmetric_coefficient_matrix(
+        V, [e1, e2], pep_context=pep_context
+    )
+
+    expected = np.array([[2.0, 1.5], [1.5, 5.0]])
+    np.testing.assert_allclose(coeff_matrix, expected, atol=1e-10)
+
+
+def test_find_basis_with_sparsest_coefficients_selects_sparse_basis(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    w = e1 + e2
+    V = w**2 + 2 * e2**2
+
+    basis, coeff_matrix = lyapunov_utils.find_basis_with_sparsest_coefficients(
+        V,
+        [e1, e2, w],
+        pep_context=pep_context,
+    )
+
+    assert basis == [e2, w]
+    np.testing.assert_allclose(
+        coeff_matrix, np.array([[2.0, 0.0], [0.0, 1.0]]), atol=1e-10
+    )
+
+
+def test_find_basis_with_sparsest_coefficients_respects_fixed_vectors(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    w = e1 + e2
+    V = w**2 + 2 * e2**2
+
+    basis, coeff_matrix = lyapunov_utils.find_basis_with_sparsest_coefficients(
+        V,
+        [e1, e2, w],
+        pep_context=pep_context,
+        fixed_vectors=[e1],
+    )
+
+    assert e1 in basis
+    assert len(basis) == 2
+    assert coeff_matrix.shape == (2, 2)
+
+
+def test_complete_basis_with_sparsifying_last_vector_eliminates_last_cross_block(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    e3 = vector.Vector(is_basis=True, tags=["e_3"])
+    V = 2 * e1**2 + 3 * e2**2 + 5 * e3**2
+
+    v_last, coeff_matrix = lyapunov_utils.complete_basis_with_sparsifying_last_vector(
+        V, [e1, e2], pep_context=pep_context, rtol=1e-12
+    )
+
+    np.testing.assert_allclose(coeff_matrix[:2, 2], np.zeros(2), atol=1e-10)
+    assert v_last.shape == (3,)
+
+
+def test_ldl_decompose_with_reversed_basis_returns_labeled_factors(
+    pep_context: pc.PEPContext, basis_vectors
+):
+    e1, e2 = basis_vectors
+    S = MatrixWithNames(
+        matrix=np.diag([2.0, 3.0]),
+        row_names=[repr(e1), repr(e2)],
+        col_names=[repr(e1), repr(e2)],
+    )
+
+    D, ell = lyapunov_utils.ldl_decompose_with_reversed_basis(
+        S, [e1, e2], print_output=False
+    )
+
+    np.testing.assert_allclose(D, np.diag([3.0, 2.0]))
+    assert len(ell) == 2

--- a/pepflow/parameter.py
+++ b/pepflow/parameter.py
@@ -344,10 +344,10 @@ class Parameter:
         self, resolve_parameters: dict[str, utils.NUMERICAL_TYPE]
     ) -> utils.NUMERICAL_TYPE:
         if self.eval_expression is None:
-            val = resolve_parameters.get(self.name, NOT_FOUND)  # ty:ignore
+            val = resolve_parameters.get(self.name, NOT_FOUND)
             if val is NOT_FOUND:
                 raise ValueError(f"Cannot resolve Parameter named: {self.name}")
-            return val
+            return val  # ty: ignore
 
         if isinstance(self.eval_expression, ParameterByDictRepresentation):
             return NotImplemented  # TODO: implement this


### PR DESCRIPTION
Add `pepflow/lyapunov_utils.py` with utilities for choosing Lyapunov basis vectors and computing coefficient matrices.

This PR introduces utilities to:

- `vectors_in_column_space`: filter vectors by membership in the column space of a Lyapunov quadratic form
- `select_independent_subset`: select linearly independent vector subsets
- `find_symmetric_coefficient_matrix`: recover symmetric coefficient matrices over a chosen vector basis
- `find_basis_with_sparsest_coefficients`: search for bases that yield sparse Lyapunov coefficient matrices
- `complete_basis_with_sparsifying_last_vector`: complete a basis with a sparsifying final vector
- `ldl_decompose_with_reversed_basis`: run labeled LDL decomposition using reversed basis ordering

It also adds example notebooks under the `examples_lyapunov` folder:

- `examples_lyapunov/gd/gd_example_lyap.ipynb`: gradient descent Lyapunov example
- `examples_lyapunov/appm/appm_example_lyap.ipynb`: APPM Lyapunov example

Focused unit tests are added in `pepflow/lyapunov_utils_test.py`.